### PR TITLE
[feat] 유리병 리스트 UI 구성 #14

### DIFF
--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		A8509E6727C85AC900855153 /* PopupTopBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8509E6627C85AC900855153 /* PopupTopBar.swift */; };
 		A8509E6C27C8991100855153 /* PopupTextInputField.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8509E6B27C8991100855153 /* PopupTextInputField.swift */; };
 		A8509E6E27C89A1200855153 /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8509E6D27C89A1200855153 /* UIColor+Extension.swift */; };
+		A89CBEDB27CBDD99005549F6 /* BottleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89CBEDA27CBDD99005549F6 /* BottleCell.swift */; };
+		A89CBEDD27CBDEA2005549F6 /* BottleListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89CBEDC27CBDEA2005549F6 /* BottleListViewController.swift */; };
 		A8BD833327BE104900E0DE41 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8BD833227BE104900E0DE41 /* HomeViewController.swift */; };
 		A8BD833527BE106C00E0DE41 /* BottleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8BD833427BE106C00E0DE41 /* BottleViewController.swift */; };
 		A8BD833F27BE30B400E0DE41 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8BD833E27BE30B400E0DE41 /* Constants.swift */; };
@@ -42,6 +44,8 @@
 		A8509E6627C85AC900855153 /* PopupTopBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupTopBar.swift; sourceTree = "<group>"; };
 		A8509E6B27C8991100855153 /* PopupTextInputField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupTextInputField.swift; sourceTree = "<group>"; };
 		A8509E6D27C89A1200855153 /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
+		A89CBEDA27CBDD99005549F6 /* BottleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleCell.swift; sourceTree = "<group>"; };
+		A89CBEDC27CBDEA2005549F6 /* BottleListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleListViewController.swift; sourceTree = "<group>"; };
 		A8BD833227BE104900E0DE41 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		A8BD833427BE106C00E0DE41 /* BottleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleViewController.swift; sourceTree = "<group>"; };
 		A8BD833E27BE30B400E0DE41 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
@@ -108,6 +112,7 @@
 				A8509E6627C85AC900855153 /* PopupTopBar.swift */,
 				A8509E6B27C8991100855153 /* PopupTextInputField.swift */,
 				A8EB5E8827C8A7B9005704F2 /* PopupPeriodSelectionField.swift */,
+				A89CBEDA27CBDD99005549F6 /* BottleCell.swift */,
 			);
 			path = Subview;
 			sourceTree = "<group>";
@@ -126,6 +131,7 @@
 				A8BD833227BE104900E0DE41 /* HomeViewController.swift */,
 				A8BD833427BE106C00E0DE41 /* BottleViewController.swift */,
 				A8E9B2A727C606D4006403E2 /* CreateNewBottlePopupViewController.swift */,
+				A89CBEDC27CBDEA2005549F6 /* BottleListViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -365,8 +371,10 @@
 				A8E9B2A827C606D4006403E2 /* CreateNewBottlePopupViewController.swift in Sources */,
 				A8BD833327BE104900E0DE41 /* HomeViewController.swift in Sources */,
 				A499318127BF3A38009FF5A8 /* BottleViewModel.swift in Sources */,
+				A89CBEDB27CBDD99005549F6 /* BottleCell.swift in Sources */,
 				A49931A527BFD20E009FF5A8 /* UIImage+AssetImages.swift in Sources */,
 				A8BD833F27BE30B400E0DE41 /* Constants.swift in Sources */,
+				A89CBEDD27CBDEA2005549F6 /* BottleListViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		A8509E6E27C89A1200855153 /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8509E6D27C89A1200855153 /* UIColor+Extension.swift */; };
 		A89CBEDB27CBDD99005549F6 /* BottleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89CBEDA27CBDD99005549F6 /* BottleCell.swift */; };
 		A89CBEDD27CBDEA2005549F6 /* BottleListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89CBEDC27CBDEA2005549F6 /* BottleListViewController.swift */; };
+		A89CBEE027CC023B005549F6 /* Bottle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89CBEDF27CC023B005549F6 /* Bottle.swift */; };
 		A8BD833327BE104900E0DE41 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8BD833227BE104900E0DE41 /* HomeViewController.swift */; };
 		A8BD833527BE106C00E0DE41 /* BottleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8BD833427BE106C00E0DE41 /* BottleViewController.swift */; };
 		A8BD833F27BE30B400E0DE41 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8BD833E27BE30B400E0DE41 /* Constants.swift */; };
@@ -46,6 +47,7 @@
 		A8509E6D27C89A1200855153 /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
 		A89CBEDA27CBDD99005549F6 /* BottleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleCell.swift; sourceTree = "<group>"; };
 		A89CBEDC27CBDEA2005549F6 /* BottleListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleListViewController.swift; sourceTree = "<group>"; };
+		A89CBEDF27CC023B005549F6 /* Bottle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bottle.swift; sourceTree = "<group>"; };
 		A8BD833227BE104900E0DE41 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		A8BD833427BE106C00E0DE41 /* BottleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleViewController.swift; sourceTree = "<group>"; };
 		A8BD833E27BE30B400E0DE41 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
@@ -115,6 +117,14 @@
 				A89CBEDA27CBDD99005549F6 /* BottleCell.swift */,
 			);
 			path = Subview;
+			sourceTree = "<group>";
+		};
+		A89CBEDE27CC0233005549F6 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				A89CBEDF27CC023B005549F6 /* Bottle.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		A8BD834227BE32EB00E0DE41 /* Button */ = {
@@ -203,6 +213,7 @@
 		A8FC07C627B3ECF00077A758 /* Happiggy-bank */ = {
 			isa = PBXGroup;
 			children = (
+				A89CBEDE27CC0233005549F6 /* Model */,
 				A87DCD3727C785D800AB0537 /* Subview */,
 				A499317F27BF3A2C009FF5A8 /* ViewModel */,
 				A8FC07C727B3ECF00077A758 /* AppDelegate.swift */,
@@ -369,6 +380,7 @@
 				A8EB5E8B27C8B087005704F2 /* UIButton+Extension.swift in Sources */,
 				A817430127C112D00016C921 /* DefaultButton.swift in Sources */,
 				A8E9B2A827C606D4006403E2 /* CreateNewBottlePopupViewController.swift in Sources */,
+				A89CBEE027CC023B005549F6 /* Bottle.swift in Sources */,
 				A8BD833327BE104900E0DE41 /* HomeViewController.swift in Sources */,
 				A499318127BF3A38009FF5A8 /* BottleViewModel.swift in Sources */,
 				A89CBEDB27CBDD99005549F6 /* BottleCell.swift in Sources */,

--- a/Happiggy-bank/Happiggy-bank/Model/Bottle.swift
+++ b/Happiggy-bank/Happiggy-bank/Model/Bottle.swift
@@ -1,0 +1,16 @@
+//
+//  Bottle.swift
+//  Happiggy-bank
+//
+//  Created by 권은빈 on 2022/02/28.
+//
+
+import Foundation
+
+// TODO: Bottle Model 수정 및 기간 계산 로직 추가
+/// 유리병 데이터 모델
+struct Bottle {
+    var id: Int
+    var title: String
+    var date: String
+}

--- a/Happiggy-bank/Happiggy-bank/Subview/BottleCell.swift
+++ b/Happiggy-bank/Happiggy-bank/Subview/BottleCell.swift
@@ -1,0 +1,148 @@
+//
+//  BottleCell.swift
+//  Happiggy-bank
+//
+//  Created by 권은빈 on 2022/02/28.
+//
+
+import UIKit
+
+import Then
+
+/// 유리병 리스트의 셀
+class BottleCell: UITableViewCell {
+    
+    // MARK: Properties
+    // TODO: 이미지로 교체
+    /// 배경
+    let background = UIView().then {
+        $0.frame = CGRect(
+            x: 0,
+            y: 0,
+            width: Metric.cellBackgroundWidth,
+            height: Metric.cellBackgroundHeight
+        )
+        $0.backgroundColor = UIColor.white
+        $0.layer.cornerRadius = 10
+        $0.translatesAutoresizingMaskIntoConstraints = false
+    }
+    
+    /// 유리병 제목 라벨
+    let titleLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: FontSize.titleLabel, weight: .bold)
+        $0.translatesAutoresizingMaskIntoConstraints = false
+    }
+    
+    /// 유리병 기간 라벨
+    let dateLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: FontSize.dateLabel)
+        $0.textColor = UIColor(hex: Color.dateLabelText)
+        $0.translatesAutoresizingMaskIntoConstraints = false
+    }
+    
+    
+    // MARK: override func
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        configureCell()
+        configureViewHierarchy()
+        configureConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    
+    // MARK: cell settings
+    
+    /// 셀 속성 설정
+    private func configureCell() {
+        self.backgroundColor = UIColor(hex: BottleListViewController.Color.tableViewBackground)
+    }
+    
+    
+    // MARK: View Hierarchy
+    
+    /// 뷰 계층 설정
+    private func configureViewHierarchy() {
+        self.addSubview(background)
+        self.background.addSubview(titleLabel)
+        self.background.addSubview(dateLabel)
+    }
+    
+    
+    // MARK: Constraints
+    
+    /// Constraints 메서드 호출하는 함수
+    private func configureConstraints() {
+        configureBackgroundConstraints()
+        configureTitleLabelConstraints()
+        configureDateLabelConstraints()
+    }
+    
+    /// 배경 Constraints 설정
+    private func configureBackgroundConstraints() {
+        NSLayoutConstraint.activate([
+            self.background.leadingAnchor.constraint(
+                equalTo: self.leadingAnchor,
+                constant: Metric.cellVerticalPadding
+            ),
+            self.background.trailingAnchor.constraint(
+                equalTo: self.trailingAnchor,
+                constant: -Metric.cellVerticalPadding
+            ),
+            self.background.topAnchor.constraint(
+                equalTo: self.topAnchor,
+                constant: Metric.cellHorizontalPadding
+            ),
+            self.background.widthAnchor.constraint(
+                equalToConstant: Metric.cellBackgroundWidth
+            ),
+            self.background.heightAnchor.constraint(
+                equalToConstant: Metric.cellBackgroundHeight
+            )
+        ])
+    }
+    
+    /// 유리병 제목 라벨 Constraints 설정
+    private func configureTitleLabelConstraints() {
+        NSLayoutConstraint.activate([
+            self.titleLabel.leadingAnchor.constraint(
+                equalTo: self.background.leadingAnchor,
+                constant: Metric.cellInnerLeadingPadding
+            ),
+            self.titleLabel.trailingAnchor.constraint(
+                equalTo: self.background.trailingAnchor,
+                constant: -Metric.cellInnerTrailingPadding
+            ),
+            self.titleLabel.topAnchor.constraint(
+                equalTo: self.background.topAnchor,
+                constant: Metric.cellInnerVerticalPadding
+            )
+        ])
+    }
+    
+    /// 유리병 기간 라벨 Constraints 설정
+    private func configureDateLabelConstraints() {
+        NSLayoutConstraint.activate([
+            self.dateLabel.leadingAnchor.constraint(
+                equalTo: self.background.leadingAnchor,
+                constant: Metric.cellInnerLeadingPadding
+            ),
+            self.dateLabel.trailingAnchor.constraint(
+                equalTo: self.background.trailingAnchor,
+                constant: -Metric.cellInnerTrailingPadding
+            ),
+            self.dateLabel.topAnchor.constraint(
+                equalTo: self.titleLabel.bottomAnchor,
+                constant: Metric.cellLabelPadding
+            ),
+            self.dateLabel.bottomAnchor.constraint(
+                equalTo: self.background.bottomAnchor,
+                constant: -Metric.cellInnerVerticalPadding
+            )
+        ])
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/Subview/BottleCell.swift
+++ b/Happiggy-bank/Happiggy-bank/Subview/BottleCell.swift
@@ -59,6 +59,7 @@ class BottleCell: UITableViewCell {
     
     /// 셀 속성 설정
     private func configureCell() {
+        self.selectionStyle = .none
         self.backgroundColor = UIColor(hex: BottleListViewController.Color.tableViewBackground)
     }
     

--- a/Happiggy-bank/Happiggy-bank/Subview/BottleCell.swift
+++ b/Happiggy-bank/Happiggy-bank/Subview/BottleCell.swift
@@ -10,7 +10,7 @@ import UIKit
 import Then
 
 /// 유리병 리스트의 셀
-class BottleCell: UITableViewCell {
+final class BottleCell: UITableViewCell {
     
     // MARK: Properties
     // TODO: 이미지로 교체

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -234,3 +234,92 @@ extension PopupPeriodSelectionField {
         static let descriptionLabel: CGFloat = 16
     }
 }
+
+extension BottleListViewController {
+    
+    /// BottleListViewController에서 설정하는 layout 상수값
+    enum Metric {
+        
+        /// 테이블뷰 행 높이
+        static let tableViewRowHeight: CGFloat = 112
+    }
+    
+    /// BottleListViewController에서 설정하는 Color 상수값
+    enum Color {
+        
+        /// 테이블뷰 배경색
+        static let tableViewBackground: Int = 0xE1C2BC
+        
+        /// 내비게이션 바 Item 색상
+        static let navigationBar: Int = 0x000000
+    }
+    
+    /// BottleListViewController에서 설정하는 글자 크기 상수값
+    enum FontSize {
+        
+        /// 리스트가 빈 경우 표시되는 라벨 글자 크기
+        static let emptyListLabelTitle: CGFloat = 16
+    }
+    
+    /// BottleListViewController에서 설정하는 문자열
+    enum StringLiteral {
+        
+        /// 리스트가 빈 경우 표시되는 내비게이션 타이틀
+        static let emptyListNavigationBarTitle: String = "지난 유리병"
+        
+        /// 리스트가 차있는 경우 표시되는 내비게이션 타이틀
+        static let fullListNavigationBarTitle: String = "지난 유리병 목록"
+        
+        /// 리스트가 빈 경우 테이블뷰에 표시되는 라벨
+        static let emptyListLabelTitle: String = "이전에 사용한 유리병이 없습니다."
+    }
+}
+
+extension BottleCell {
+    
+    /// Bottle Cell에서 설정하는 layout 상수값
+    enum Metric {
+        
+        /// 셀 배경 너비
+        static let cellBackgroundWidth: CGFloat =
+        UIScreen.main.bounds.width - cellHorizontalPadding * 2
+        
+        /// 셀 배경 높이
+        static let cellBackgroundHeight: CGFloat = 96
+        
+        /// 셀 수평 패딩
+        static let cellHorizontalPadding: CGFloat = 16
+        
+        /// 셀 수직 패딩
+        static let cellVerticalPadding: CGFloat = 16
+        
+        /// 셀 내부 앞쪽 패딩
+        static let cellInnerLeadingPadding: CGFloat = 16
+        
+        /// 셀 내부 뒤쪽 패딩
+        static let cellInnerTrailingPadding: CGFloat = 56
+        
+        /// 셀 내부 수직 패딩
+        static let cellInnerVerticalPadding: CGFloat = 24
+        
+        /// 셀 내부 라벨 간 패딩
+        static let cellLabelPadding: CGFloat = 12
+    }
+    
+    /// Bottle Cell에서 설정하는 글자 크기
+    enum FontSize {
+        
+        /// 유리병 제목 라벨 글자 크기
+        static let titleLabel: CGFloat = 16
+        
+        /// 유리병 기간 라벨 글자 크기
+        static let dateLabel: CGFloat = 16
+    }
+    
+    /// Bottle Cell에서 설정하는 색상 상수값
+    enum Color {
+        
+        /// 유리병 기간 라벨 색상
+        static let dateLabelText: Int = 0xA19491
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/ViewController/BottleListViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/BottleListViewController.swift
@@ -1,0 +1,159 @@
+//
+//  BottleListViewController.swift
+//  Happiggy-bank
+//
+//  Created by 권은빈 on 2022/02/28.
+//
+
+import UIKit
+
+import Then
+
+// TODO: Bottle Model 수정 및 기간 계산 로직 추가
+struct Bottle {
+    var title: String
+    var date: String
+}
+
+/// 유리병 리스트 뷰 컨트롤러
+class BottleListViewController: UIViewController {
+    
+    // MARK: Properties
+    // TODO: View Model로 이동
+    /// 유리병 리스트(임시)
+    lazy var bottleList: [Bottle] = {
+        var bottles = [Bottle]()
+        
+        for index in 0...3 {
+            let bottle = Bottle(title: "bottle \(index)", date: "2022.01.01 ~ 2022.01.31")
+            bottles.append(bottle)
+        }
+        
+        return bottles
+    }()
+    
+    /// 유리병 리스트 테이블 뷰
+    lazy var tableView = UITableView().then {
+        $0.frame = CGRect(
+            x: 0,
+            y: 0,
+            width: UIScreen.main.bounds.width,
+            height: UIScreen.main.bounds.height
+        )
+        $0.backgroundColor = UIColor(hex: Color.tableViewBackground)
+        $0.separatorStyle = .none
+        $0.rowHeight = Metric.tableViewRowHeight
+        $0.translatesAutoresizingMaskIntoConstraints = false
+    }
+    
+    /// 유리병 리스트가 빈 경우 표시하는 라벨
+    lazy var emptyListLabel = UILabel().then {
+        $0.text = StringLiteral.emptyListLabelTitle
+        $0.font = .systemFont(ofSize: FontSize.emptyListLabelTitle)
+        $0.translatesAutoresizingMaskIntoConstraints = false
+    }
+    
+    
+    // MARK: Lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureNavigationBar()
+        configureTableView()
+        configureViewHierarchy()
+        hideEmptyListLabelIfNeeded()
+        configureConstraints()
+    }
+    
+    
+    // MARK: View Configuration
+    
+    /// 내비게이션 바 속성 설정
+    private func configureNavigationBar() {
+        self.navigationController?.navigationBar.tintColor = UIColor(hex: Color.navigationBar)
+        self.title = bottleList.isEmpty ?
+        StringLiteral.emptyListNavigationBarTitle :
+        StringLiteral.fullListNavigationBarTitle
+    }
+    
+    /// 테이블 뷰 속성 설정
+    private func configureTableView() {
+        self.tableView.register(BottleCell.self, forCellReuseIdentifier: "BottleCell")
+        self.tableView.delegate = self
+        self.tableView.dataSource = self
+    }
+    
+    /// 뷰 계층 설정
+    private func configureViewHierarchy() {
+        self.view.addSubview(tableView)
+        self.tableView.addSubview(emptyListLabel)
+    }
+    
+    /// 유리병 리스트가 차있는 경우, 테이블뷰에 표시되는 라벨 감추기
+    private func hideEmptyListLabelIfNeeded() {
+        if !bottleList.isEmpty {
+            self.emptyListLabel.isHidden = true
+        }
+    }
+    
+    
+    // MARK: Constraints
+    /// Constraints 메서드 호출하는 함수
+    private func configureConstraints() {
+        configureTableViewConstraints()
+        configureEmptyListLabelConstraints()
+    }
+    
+    /// 테이블 뷰 Constraints
+    private func configureTableViewConstraints() {
+        NSLayoutConstraint.activate([
+            self.tableView.topAnchor.constraint(equalTo: self.view.topAnchor),
+            self.tableView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            self.tableView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+            self.tableView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor)
+        ])
+    }
+    
+    /// 유리병이 빈 경우 표시되는 라벨 Constraints
+    private func configureEmptyListLabelConstraints() {
+        NSLayoutConstraint.activate([
+            self.emptyListLabel.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            self.emptyListLabel.centerYAnchor.constraint(equalTo: self.view.centerYAnchor)
+        ])
+    }
+}
+
+extension BottleListViewController: UITableViewDataSource {
+    
+    /// 테이블 뷰의 셀 개수 리턴하는 함수
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return self.bottleList.count
+    }
+    
+    // swiftlint:disable force_cast
+    /// 셀을 구성하는 함수
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let bottle = bottleList[indexPath.row]
+        let cell = tableView.dequeueReusableCell(
+            withIdentifier: "BottleCell",
+            for: indexPath
+        ) as! BottleCell
+        
+        resetReusableCellAttribute(cell)
+        cell.titleLabel.text = bottle.title
+        cell.dateLabel.text = bottle.date
+        
+        return cell
+    }
+    // swiftlint:enable force_cast
+    
+    /// 리유저블 셀의 속성 초기화하는 함수
+    private func resetReusableCellAttribute(_ cell: BottleCell) {
+        cell.titleLabel.text = ""
+        cell.dateLabel.text = ""
+    }
+}
+
+extension BottleListViewController: UITableViewDelegate {
+    // Delegate
+}

--- a/Happiggy-bank/Happiggy-bank/ViewController/BottleListViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/BottleListViewController.swift
@@ -11,6 +11,7 @@ import Then
 
 // TODO: Bottle Model 수정 및 기간 계산 로직 추가
 struct Bottle {
+    var id: Int
     var title: String
     var date: String
 }
@@ -25,7 +26,7 @@ class BottleListViewController: UIViewController {
         var bottles = [Bottle]()
         
         for index in 0...3 {
-            let bottle = Bottle(title: "bottle \(index)", date: "2022.01.01 ~ 2022.01.31")
+            let bottle = Bottle(id: index, title: "bottle \(index)", date: "2022.01.01 ~ 2022.01.31")
             bottles.append(bottle)
         }
         
@@ -155,5 +156,13 @@ extension BottleListViewController: UITableViewDataSource {
 }
 
 extension BottleListViewController: UITableViewDelegate {
-    // Delegate
+    
+    // TODO: GET from server
+    // TODO: HomeVC currentIndex update
+    /// 특정 행을 선택했을 때 호출되는 함수
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let bottleId = bottleList[indexPath.row].id
+        print("get bottle data from db with \(bottleId)")
+        self.navigationController?.popViewController(animated: true)
+    }
 }

--- a/Happiggy-bank/Happiggy-bank/ViewController/BottleListViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/BottleListViewController.swift
@@ -9,17 +9,11 @@ import UIKit
 
 import Then
 
-// TODO: Bottle Model 수정 및 기간 계산 로직 추가
-struct Bottle {
-    var id: Int
-    var title: String
-    var date: String
-}
-
 /// 유리병 리스트 뷰 컨트롤러
-class BottleListViewController: UIViewController {
+final class BottleListViewController: UIViewController {
     
     // MARK: Properties
+    
     // TODO: View Model로 이동
     /// 유리병 리스트(임시)
     lazy var bottleList: [Bottle] = {

--- a/Happiggy-bank/Happiggy-bank/ViewController/HomeViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/HomeViewController.swift
@@ -78,7 +78,9 @@ final class HomeViewController: UIViewController {
     
     /// 유리병 리스트 버튼 탭할 시 실행되는 함수
     @objc func userJarListButtonDidTap(_ sender: UIButton) {
-        print("Move to User Jar List View")
+        let bottleListViewController: BottleListViewController = BottleListViewController()
+        self.navigationItem.backButtonTitle = ""
+        self.navigationController?.pushViewController(bottleListViewController, animated: true)
     }
     
     /// 진행중인 유리병이 없을 시에 나타나는 초기 이미지 탭할 시 실행되는 함수


### PR DESCRIPTION
## 반영 내용

유리병 리스트 UI 구성 (issue #14)

### BottleListViewController
- 유리병 리스트 뷰 컨트롤러
- 리유저블셀을 사용해 테이블 뷰 구성
- 리스트가 비어있을때와 차있을 때 내비게이션 타이틀 변경 및 테이블 뷰 라벨 visible/hidden

### BottleCell
- 유리병 테이블 뷰 셀
- 추후 이미지로 배경 교체 예정

## 추후 개발 내용
- UI 상세(이미지 등)
- 데이터 바인딩
- 각 유리병 선택시 HomeVC에 반영