### PR TITLE
[chore] SwiftLint 경로 문제로 build phase run script 변경 #17

### DIFF
--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -341,7 +341,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if test -d \"/opt/homebrew/bin/\"; then\n  PATH=\"/opt/homebrew/bin/:${PATH}\"\nfi\n\nexport PATH\n\nif which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
## 관련 이슈
- 이슈 #17

<br>

## 적용 내용
- 로컬에서 brew 로 SwiftLint 설치 후 CLI 에서는 작동하는데 Xcode 에서는 계속 설치되지 않았다고 떠서 Build Phase 의 Run Script 를 변경(경로 관련 문제)
  - 바뀐 런스크립트가 은빈님 로컬에서도 괜찮은지 확인 필요
- 커밋 메시지 분류가 애매한 것 같아서 chore 항목 추가
  - [참고 링크](https://doublesprogramming.tistory.com/256)