### PR TITLE
[feat] 화면 재구성 #21

### DIFF
--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,66 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "SourceKitten",
-        "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
-        "state": {
-          "branch": null,
-          "revision": "558628392eb31d37cb251cfe626c53eafd330df6",
-          "version": "0.31.1"
-        }
-      },
-      {
-        "package": "swift-argument-parser",
-        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
-        "state": {
-          "branch": null,
-          "revision": "e394bf350e38cb100b6bc4172834770ede1b7232",
-          "version": "1.0.3"
-        }
-      },
-      {
-        "package": "SwiftLint",
-        "repositoryURL": "https://github.com/realm/SwiftLint.git",
-        "state": {
-          "branch": null,
-          "revision": "9c81e1a93a367db773f50c85229d942d0bb9aeaf",
-          "version": "0.46.3"
-        }
-      },
-      {
-        "package": "SwiftyTextTable",
-        "repositoryURL": "https://github.com/scottrhoyt/SwiftyTextTable.git",
-        "state": {
-          "branch": null,
-          "revision": "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
-          "version": "0.9.0"
-        }
-      },
-      {
-        "package": "SWXMLHash",
-        "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
-        "state": {
-          "branch": null,
-          "revision": "9183170d20857753d4f331b0ca63f73c60764bf3",
-          "version": "5.0.2"
-        }
-      },
-      {
         "package": "Then",
         "repositoryURL": "https://github.com/devxoul/Then.git",
         "state": {
           "branch": null,
           "revision": "e421a7b3440a271834337694e6050133a3958bc7",
           "version": "2.7.0"
-        }
-      },
-      {
-        "package": "Yams",
-        "repositoryURL": "https://github.com/jpsim/Yams.git",
-        "state": {
-          "branch": null,
-          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-          "version": "4.0.6"
         }
       }
     ]

--- a/Happiggy-bank/Happiggy-bank/Info.plist
+++ b/Happiggy-bank/Happiggy-bank/Info.plist
@@ -15,6 +15,8 @@
 					<string>Default Configuration</string>
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
 				</dict>
 			</array>
 		</dict>

--- a/Happiggy-bank/Happiggy-bank/SceneDelegate.swift
+++ b/Happiggy-bank/Happiggy-bank/SceneDelegate.swift
@@ -16,12 +16,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let windowScene = (scene as? UIWindowScene) else { return }
-        let window = UIWindow(windowScene: windowScene)
-        let navigationController = UINavigationController(rootViewController: HomeViewController())
-        window.rootViewController = navigationController
-        window.makeKeyAndVisible()
-        self.window = window
+        guard let _ = (scene as? UIWindowScene) else { return }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="dSD-O6-Yej">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -9,10 +9,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Home View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Happiggy_bank" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="HomeViewController" customModule="Happiggy_bank" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -21,12 +21,120 @@
                     </view>
                     <navigationItem key="navigationItem" id="P6e-3z-28Z"/>
                     <connections>
-                        <outlet property="mainView" destination="8bC-Xf-vdC" id="eNZ-Z9-eJs"/>
+                        <outlet property="homeView" destination="8bC-Xf-vdC" id="edO-Zc-7da"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="48" y="1688"/>
+        </scene>
+        <!--Bottle List View Controller-->
+        <scene sceneID="IHR-JB-pwa">
+            <objects>
+                <viewController id="zPZ-4s-ZPb" customClass="BottleListViewController" customModule="Happiggy_bank" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="g3S-Jh-zW0">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="cUP-8i-uYm"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="l40-Fa-bkL"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="QCW-48-qYH" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="893" y="1688"/>
+        </scene>
+        <!--Home-->
+        <scene sceneID="YE7-1s-WX3">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="LDk-3h-IzZ" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Home" id="Eeg-1d-ksO"/>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="wRZ-jI-V9m">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="QkS-Gy-beP"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="YF6-5E-brh" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="49" y="868"/>
+        </scene>
+        <!--Tab Bar Controller-->
+        <scene sceneID="y3u-6K-UTc">
+            <objects>
+                <tabBarController automaticallyAdjustsScrollViewInsets="NO" id="dSD-O6-Yej" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <tabBar key="tabBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="Tog-A2-SCB">
+                        <autoresizingMask key="autoresizingMask"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </tabBar>
+                    <connections>
+                        <segue destination="LDk-3h-IzZ" kind="relationship" relationship="viewControllers" id="MHL-oV-ZTp"/>
+                        <segue destination="ZUl-P8-w21" kind="relationship" relationship="viewControllers" id="nZb-Ae-VMG"/>
+                        <segue destination="rvN-Mi-KI9" kind="relationship" relationship="viewControllers" id="yPk-Sm-mQ1"/>
+                    </connections>
+                </tabBarController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="5Il-OJ-Qd0" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
             <point key="canvasLocation" x="892.75362318840587" y="38.839285714285715"/>
+        </scene>
+        <!--Bottle List-->
+        <scene sceneID="ffE-9v-wjj">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="ZUl-P8-w21" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Bottle List" id="RUG-PV-yjD"/>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="PEg-Az-WTy">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="zPZ-4s-ZPb" kind="relationship" relationship="rootViewController" id="D9l-Ev-kMS"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="2lx-ry-UpU" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="893" y="868"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="EbK-dk-XXq">
+            <objects>
+                <viewController id="IlI-sf-Vas" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="pEH-8i-4vx">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="NL0-gI-uP8"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="ahV-wP-HPl"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="aNi-4h-ywR" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1738" y="1688"/>
+        </scene>
+        <!--Settings-->
+        <scene sceneID="vw8-MY-aV0">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="rvN-Mi-KI9" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Settings" id="LtB-vV-jcX"/>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="1ha-RM-7e9">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="IlI-sf-Vas" kind="relationship" relationship="rootViewController" id="hej-Sj-02l"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="zeo-ty-sXm" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1738" y="868"/>
         </scene>
     </scenes>
     <resources>

--- a/Happiggy-bank/Happiggy-bank/ViewController/BottleViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/BottleViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import Then
 
+// TODO: 진행중인 유리병 있는지 없는지에 따라 초기 화면 구성 및 동작 수행 필요
 /// 각 bottle 의 뷰를 관리하는 컨트롤러
 final class BottleViewController: UIViewController {
     

--- a/Happiggy-bank/Happiggy-bank/ViewController/HomeViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/HomeViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-// TODO: Then 사용해서 property 초기화
+// TODO: Bottle Label 디자인 확정시 추가
 /// 메인 화면 전체를 관리하는 컨트롤러
 final class HomeViewController: UIViewController {
     
@@ -16,34 +16,18 @@ final class HomeViewController: UIViewController {
     /// HomeViewController의 뷰
     @IBOutlet var homeView: UIView!
     
-    /// 환경설정 버튼
-    var settingsButton: UIButton!
-    
-    /// 개봉 버튼
-    var openBeforeFinishedButton: UIButton!
-    
-    /// 유리병 리스트 버튼
-    var bottleListButton: UIButton!
-    
-    /// 현재까지의 쪽지와 목표치를 나타내는 라벨
-    var noteProgressLabel: UIView!
-    
     /// 유리병 뷰를 관리하는 컨트롤러
     var bottleViewController: BottleViewController!
-    
-    /// 홈 뷰의 뷰모델
-    private var homeViewModel: HomeViewModel = HomeViewModel()
     
     
     // MARK: - LifeCycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureView()
-        configureConstraints()
-        if !homeViewModel.hasBottle {
-            hideUnusedButtonAndLabels()
-        }
+        navigationItem.backButtonTitle = ""
+        configureBottleViewController()
+        configureViewHierarchy()
+        configureBottleViewConstraints()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -58,206 +42,49 @@ final class HomeViewController: UIViewController {
         self.navigationController?.setNavigationBarHidden(false, animated: animated)
     }
     
-    // MARK: - Button Actions(@objc functions)
-    
-    /// 환경설정 버튼 탭할 시 실행되는 함수
-    @objc func settingsButtonDidTap(_ sender: UIButton) {
-        print("Move to Settings View")
-    }
-    
-    /// 개봉 버튼 탭할 시 실행되는 함수
-    @objc func openBeforeFinishedButtonDidTap(_ sender: UIButton) {
-        print("Open the jar")
-    }
-    
-    /// 유리병 리스트 버튼 탭할 시 실행되는 함수
-    @objc func userJarListButtonDidTap(_ sender: UIButton) {
-        let bottleListViewController: BottleListViewController = BottleListViewController()
-        self.navigationItem.backButtonTitle = ""
-        self.navigationController?.pushViewController(bottleListViewController, animated: true)
-    }
-    
-    /// 진행중인 유리병이 없을 시에 나타나는 초기 이미지 탭할 시 실행되는 함수
-    @objc func initialImageViewDidTap(_ sender: UITapGestureRecognizer) {
-        let createNewBottleViewController: CreateNewBottlePopupViewController
-        = CreateNewBottlePopupViewController()
-        
-        createNewBottleViewController.modalPresentationStyle = .overCurrentContext
-        present(createNewBottleViewController, animated: false)
-    }
-    
-    
-    // MARK: - Actions
-    
-    /// 현재 인덱스로 BottleViewController 생성
-    func makeBottleViewController() -> BottleViewController {
-        let bottleViewController: BottleViewController = BottleViewController()
-        let bottleViewModel = BottleViewModel()
-        // TODO: currentIndex 의 bottleID 넘겨주기
-        bottleViewModel.bottleID = UUID().hashValue
-        bottleViewController.viewModel = bottleViewModel
-        return bottleViewController
-    }
-    
-    
-    // MARK: - UI Configurations
-    
-    /// 홈 뷰 UI 요소들 생성 및 HomeViewController의 하위 뷰로 추가
-    private func configureView() {
-        configureHomeView()
-        configureButtons()
-        configureLabel()
-    }
-    
-    /// 홈 뷰 생성 및 추가
-    private func configureHomeView() {
-        navigationItem.backButtonTitle = ""
-        configureBottleViewController()
-
-    }
-    
-    /// 버튼 생성,  타겟 설정 및 추가
-    private func configureButtons() {
-        self.settingsButton = DefaultButton(imageName: "gearshape")
-        self.openBeforeFinishedButton = DefaultButton(imageName: "hammer")
-        self.bottleListButton = DefaultButton(imageName: "list.bullet")
-        self.homeView.addSubview(settingsButton)
-        self.homeView.addSubview(openBeforeFinishedButton)
-        self.homeView.addSubview(bottleListButton)
-        self.settingsButton.addTarget(
-            self,
-            action: #selector(settingsButtonDidTap(_:)),
-            for: .touchUpInside
-        )
-        self.openBeforeFinishedButton.addTarget(
-            self,
-            action: #selector(openBeforeFinishedButtonDidTap(_:)),
-            for: .touchUpInside
-        )
-        self.bottleListButton.addTarget(
-            self,
-            action: #selector(userJarListButtonDidTap(_:)),
-            for: .touchUpInside
-        )
-    }
-    
-    /// 라벨 생성 및 추가
-    private func configureLabel() {
-        self.noteProgressLabel = NoteProgressLabel()
-        self.homeView.addSubview(noteProgressLabel)
-    }
-    
     
     // MARK: - Controller Configurations
     
-    /// PageViewController 구성
+    /// BottleViewController 구성 및 추가
     private func configureBottleViewController() {
         self.bottleViewController = BottleViewController()
         let bottleViewModel = BottleViewModel()
-        // TODO: currentIndex 의 bottleID 넘겨주기
+        // TODO: 현재 진행중인 유리병의 bottleID 넘겨주기
         bottleViewModel.bottleID = UUID().hashValue
         bottleViewController.viewModel = bottleViewModel
-        
+    }
+    
+    
+    // MARK: - View Hierarchy
+    
+    private func configureViewHierarchy() {
         self.addChild(bottleViewController)
         self.homeView.addSubview(bottleViewController.view)
     }
     
     
     // MARK: - Constraints
-    
-    /// 홈 뷰 UI 요소(버튼, 라벨)의 오토레이아웃 적용
-    private func configureConstraints() {
-        configureButtonConstraints()
-        configureLabelConstraints()
-        configureBottleViewConstraints()
-    }
-    
-    /// 버튼의 오토 레이아웃 적용
-    private func configureButtonConstraints() {
-        self.settingsButton.translatesAutoresizingMaskIntoConstraints = false
-        self.openBeforeFinishedButton.translatesAutoresizingMaskIntoConstraints = false
-        self.bottleListButton.translatesAutoresizingMaskIntoConstraints = false
-        
-        NSLayoutConstraint.activate([
-            settingsButton.topAnchor.constraint(
-                equalTo: self.homeView.safeAreaLayoutGuide.topAnchor
-            ),
-            settingsButton.trailingAnchor.constraint(
-                equalTo: self.homeView.trailingAnchor,
-                constant: -Metric.verticalPadding
-            ),
-            openBeforeFinishedButton.leadingAnchor.constraint(
-                equalTo: self.homeView.leadingAnchor,
-                constant: Metric.verticalPadding
-            ),
-            openBeforeFinishedButton.bottomAnchor.constraint(
-                equalTo: self.homeView.safeAreaLayoutGuide.bottomAnchor,
-                constant: -Metric.verticalPadding
-            ),
-            bottleListButton.leadingAnchor.constraint(
-                equalTo: self.homeView.leadingAnchor,
-                constant: Metric.listButtonLeadingPadding
-            ),
-            bottleListButton.bottomAnchor.constraint(
-                equalTo: self.homeView.safeAreaLayoutGuide.bottomAnchor,
-                constant: -Metric.verticalPadding
-            ),
-            settingsButton.widthAnchor.constraint(equalToConstant: Metric.buttonWidth),
-            settingsButton.heightAnchor.constraint(equalToConstant: Metric.buttonHeight),
-            openBeforeFinishedButton.widthAnchor.constraint(
-                equalToConstant: Metric.buttonWidth
-            ),
-            openBeforeFinishedButton.heightAnchor.constraint(
-                equalToConstant: Metric.buttonHeight
-            ),
-            bottleListButton.widthAnchor.constraint(equalToConstant: Metric.buttonWidth),
-            bottleListButton.heightAnchor.constraint(equalToConstant: Metric.buttonHeight)
-        ])
-    }
-    
+
+    // TODO: UI 디자인 확정시 변경
     /// BottleViewController의 뷰 오토 레이아웃 적용
     private func configureBottleViewConstraints() {
         self.bottleViewController.view.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            bottleViewController.view.widthAnchor.constraint(equalTo: view.widthAnchor),
+            bottleViewController.view.widthAnchor.constraint(
+                equalTo: view.widthAnchor
+            ),
             bottleViewController.view.heightAnchor.constraint(
                 equalTo: view.widthAnchor,
-                multiplier: Metric.pageViewHeightWidthRatio),
+                multiplier: Metric.pageViewHeightWidthRatio
+            ),
             bottleViewController.view.bottomAnchor.constraint(
-                equalTo: self.noteProgressLabel.topAnchor,
-                constant: -Metric.spacing),
-            bottleViewController.view.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+                equalTo: self.homeView.safeAreaLayoutGuide.bottomAnchor,
+                constant: -Metric.spacing
+            ),
+            bottleViewController.view.centerXAnchor.constraint(
+                equalTo: view.centerXAnchor
+            )
         ])
         bottleViewController.view.backgroundColor = .systemOrange
-    }
-    
-    /// 라벨의 오토 레이아웃 적용
-    private func configureLabelConstraints() {
-        self.noteProgressLabel.translatesAutoresizingMaskIntoConstraints = false
-        
-        NSLayoutConstraint.activate([
-            noteProgressLabel.bottomAnchor.constraint(
-                equalTo: self.homeView.safeAreaLayoutGuide.bottomAnchor,
-                constant: -Metric.verticalPadding
-            ),
-            noteProgressLabel.trailingAnchor.constraint(
-                equalTo: self.homeView.trailingAnchor,
-                constant: -Metric.verticalPadding
-            ),
-            noteProgressLabel.widthAnchor.constraint(
-                equalToConstant: Metric.noteProgressLabelWidth
-            ),
-            noteProgressLabel.heightAnchor.constraint(equalToConstant: Metric.labelHeight)
-        ])
-    }
-    
-    
-    // MARK: - Initial View Setting
-    
-    /// 진행중이 유리병이 없을시, 하단 버튼과 라벨 숨김
-    private func hideUnusedButtonAndLabels() {
-        self.openBeforeFinishedButton.isHidden = true
-        self.bottleListButton.isHidden = true
-        self.noteProgressLabel.isHidden = true
     }
 }

--- a/Happiggy-bank/Happiggy-bank/ViewController/HomeViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/HomeViewController.swift
@@ -1,5 +1,5 @@
 //
-//  HomePageViewController.swift
+//  HomeViewController.swift
 //  Happiggy-bank
 //
 //  Created by 권은빈 on 2022/02/16.
@@ -13,8 +13,8 @@ final class HomeViewController: UIViewController {
     
     // MARK: - Properties
     
-    /// 메인 뷰
-    var homeView: UIView!
+    /// HomeViewController의 뷰
+    @IBOutlet var homeView: UIView!
     
     /// 환경설정 버튼
     var settingsButton: UIButton!
@@ -28,8 +28,8 @@ final class HomeViewController: UIViewController {
     /// 현재까지의 쪽지와 목표치를 나타내는 라벨
     var noteProgressLabel: UIView!
     
-    /// 페이지 뷰를 관리하는 컨트롤러
-    var pageViewController: UIPageViewController!
+    /// 유리병 뷰를 관리하는 컨트롤러
+    var bottleViewController: BottleViewController!
     
     /// 홈 뷰의 뷰모델
     private var homeViewModel: HomeViewModel = HomeViewModel()
@@ -39,18 +39,10 @@ final class HomeViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        navigationItem.backButtonTitle = ""
-        
         configureView()
         configureConstraints()
         if !homeViewModel.hasBottle {
             hideUnusedButtonAndLabels()
-            setInitialImage()
-        }
-        if homeViewModel.hasBottle {
-            configurePageViewController()
-            configurePageViewConstraints()
         }
     }
     
@@ -98,13 +90,12 @@ final class HomeViewController: UIViewController {
     // MARK: - Actions
     
     /// 현재 인덱스로 BottleViewController 생성
-    func makePageContentViewController(with index: Int) -> BottleViewController {
+    func makeBottleViewController() -> BottleViewController {
         let bottleViewController: BottleViewController = BottleViewController()
         let bottleViewModel = BottleViewModel()
         // TODO: currentIndex 의 bottleID 넘겨주기
         bottleViewModel.bottleID = UUID().hashValue
         bottleViewController.viewModel = bottleViewModel
-        bottleViewController.index = index
         return bottleViewController
     }
     
@@ -113,15 +104,16 @@ final class HomeViewController: UIViewController {
     
     /// 홈 뷰 UI 요소들 생성 및 HomeViewController의 하위 뷰로 추가
     private func configureView() {
-        configureMainView()
+        configureHomeView()
         configureButtons()
         configureLabel()
     }
     
     /// 홈 뷰 생성 및 추가
-    private func configureMainView() {
-        self.homeView = HomeView()
-        self.view.addSubview(homeView)
+    private func configureHomeView() {
+        navigationItem.backButtonTitle = ""
+        configureBottleViewController()
+
     }
     
     /// 버튼 생성,  타겟 설정 및 추가
@@ -129,9 +121,9 @@ final class HomeViewController: UIViewController {
         self.settingsButton = DefaultButton(imageName: "gearshape")
         self.openBeforeFinishedButton = DefaultButton(imageName: "hammer")
         self.bottleListButton = DefaultButton(imageName: "list.bullet")
-        self.view.addSubview(settingsButton)
-        self.view.addSubview(openBeforeFinishedButton)
-        self.view.addSubview(bottleListButton)
+        self.homeView.addSubview(settingsButton)
+        self.homeView.addSubview(openBeforeFinishedButton)
+        self.homeView.addSubview(bottleListButton)
         self.settingsButton.addTarget(
             self,
             action: #selector(settingsButtonDidTap(_:)),
@@ -152,33 +144,22 @@ final class HomeViewController: UIViewController {
     /// 라벨 생성 및 추가
     private func configureLabel() {
         self.noteProgressLabel = NoteProgressLabel()
-        self.view.addSubview(noteProgressLabel)
+        self.homeView.addSubview(noteProgressLabel)
     }
     
     
     // MARK: - Controller Configurations
     
     /// PageViewController 구성
-    private func configurePageViewController() {
-        let startViewController: BottleViewController = self.makePageContentViewController(
-            with: homeViewModel.currentIndex
-        )
-        let viewControllerArray: [UIViewController] = [startViewController]
+    private func configureBottleViewController() {
+        self.bottleViewController = BottleViewController()
+        let bottleViewModel = BottleViewModel()
+        // TODO: currentIndex 의 bottleID 넘겨주기
+        bottleViewModel.bottleID = UUID().hashValue
+        bottleViewController.viewModel = bottleViewModel
         
-        self.pageViewController = UIPageViewController(
-            transitionStyle: .scroll,
-            navigationOrientation: .horizontal
-        )
-        self.pageViewController.dataSource = self
-        self.pageViewController.delegate = self
-        self.pageViewController.setViewControllers(
-            viewControllerArray,
-            direction: .forward,
-            animated: false,
-            completion: nil
-        )
-        self.addChild(self.pageViewController)
-        self.homeView.addSubview(self.pageViewController.view)
+        self.addChild(bottleViewController)
+        self.homeView.addSubview(bottleViewController.view)
     }
     
     
@@ -188,6 +169,7 @@ final class HomeViewController: UIViewController {
     private func configureConstraints() {
         configureButtonConstraints()
         configureLabelConstraints()
+        configureBottleViewConstraints()
     }
     
     /// 버튼의 오토 레이아웃 적용
@@ -198,26 +180,26 @@ final class HomeViewController: UIViewController {
         
         NSLayoutConstraint.activate([
             settingsButton.topAnchor.constraint(
-                equalTo: self.view.safeAreaLayoutGuide.topAnchor
+                equalTo: self.homeView.safeAreaLayoutGuide.topAnchor
             ),
             settingsButton.trailingAnchor.constraint(
-                equalTo: self.view.trailingAnchor,
+                equalTo: self.homeView.trailingAnchor,
                 constant: -Metric.verticalPadding
             ),
             openBeforeFinishedButton.leadingAnchor.constraint(
-                equalTo: self.view.leadingAnchor,
+                equalTo: self.homeView.leadingAnchor,
                 constant: Metric.verticalPadding
             ),
             openBeforeFinishedButton.bottomAnchor.constraint(
-                equalTo: self.view.safeAreaLayoutGuide.bottomAnchor,
+                equalTo: self.homeView.safeAreaLayoutGuide.bottomAnchor,
                 constant: -Metric.verticalPadding
             ),
             bottleListButton.leadingAnchor.constraint(
-                equalTo: self.view.leadingAnchor,
+                equalTo: self.homeView.leadingAnchor,
                 constant: Metric.listButtonLeadingPadding
             ),
             bottleListButton.bottomAnchor.constraint(
-                equalTo: self.view.safeAreaLayoutGuide.bottomAnchor,
+                equalTo: self.homeView.safeAreaLayoutGuide.bottomAnchor,
                 constant: -Metric.verticalPadding
             ),
             settingsButton.widthAnchor.constraint(equalToConstant: Metric.buttonWidth),
@@ -233,20 +215,20 @@ final class HomeViewController: UIViewController {
         ])
     }
     
-    /// PageViewController의 뷰 오토 레이아웃 적용
-    private func configurePageViewConstraints() {
-        self.pageViewController.view.translatesAutoresizingMaskIntoConstraints = false
+    /// BottleViewController의 뷰 오토 레이아웃 적용
+    private func configureBottleViewConstraints() {
+        self.bottleViewController.view.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            pageViewController.view.widthAnchor.constraint(equalTo: view.widthAnchor),
-            pageViewController.view.heightAnchor.constraint(
+            bottleViewController.view.widthAnchor.constraint(equalTo: view.widthAnchor),
+            bottleViewController.view.heightAnchor.constraint(
                 equalTo: view.widthAnchor,
                 multiplier: Metric.pageViewHeightWidthRatio),
-            pageViewController.view.bottomAnchor.constraint(
+            bottleViewController.view.bottomAnchor.constraint(
                 equalTo: self.noteProgressLabel.topAnchor,
                 constant: -Metric.spacing),
-            pageViewController.view.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+            bottleViewController.view.centerXAnchor.constraint(equalTo: view.centerXAnchor)
         ])
-        pageViewController.view.backgroundColor = .systemOrange
+        bottleViewController.view.backgroundColor = .systemOrange
     }
     
     /// 라벨의 오토 레이아웃 적용
@@ -255,11 +237,11 @@ final class HomeViewController: UIViewController {
         
         NSLayoutConstraint.activate([
             noteProgressLabel.bottomAnchor.constraint(
-                equalTo: self.view.safeAreaLayoutGuide.bottomAnchor,
+                equalTo: self.homeView.safeAreaLayoutGuide.bottomAnchor,
                 constant: -Metric.verticalPadding
             ),
             noteProgressLabel.trailingAnchor.constraint(
-                equalTo: self.view.trailingAnchor,
+                equalTo: self.homeView.trailingAnchor,
                 constant: -Metric.verticalPadding
             ),
             noteProgressLabel.widthAnchor.constraint(
@@ -277,103 +259,5 @@ final class HomeViewController: UIViewController {
         self.openBeforeFinishedButton.isHidden = true
         self.bottleListButton.isHidden = true
         self.noteProgressLabel.isHidden = true
-    }
-    
-    /// 진행중인 유리병이 없을시, 초기 이미지로 홈 뷰 구성
-    private func setInitialImage() {
-        let initialImageView: UIImageView = BottleImageView(image: UIImage.initialBottle)
-        let tapGesture = UITapGestureRecognizer(
-            target: self,
-            action: #selector(initialImageViewDidTap(_:))
-        )
-        self.homeView.addSubview(initialImageView)
-        initialImageView.isUserInteractionEnabled = true
-        initialImageView.addGestureRecognizer(tapGesture)
-        initialImageView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            initialImageView.widthAnchor.constraint(
-                equalTo: self.homeView.widthAnchor,
-                constant: -Metric.verticalPadding * 2),
-            initialImageView.heightAnchor.constraint(
-                equalTo: self.homeView.widthAnchor,
-                multiplier: Metric.pageViewHeightWidthRatio),
-            initialImageView.bottomAnchor.constraint(
-                equalTo: self.noteProgressLabel.topAnchor,
-                constant: -Metric.spacing),
-            initialImageView.centerXAnchor.constraint(equalTo: self.homeView.centerXAnchor)
-        ])
-    }
-}
-
-
-// MARK: - DataSource
-
-extension HomeViewController: UIPageViewControllerDataSource {
-    
-    // TODO: ViewModel 로 옮기기
-    /// 종료되지 않은 유리병의 존재 여부
-    private var hasBottleInProgress: Bool { false }
-    
-    // swiftlint:disable force_cast
-    func pageViewController(
-        _ pageViewController: UIPageViewController,
-        viewControllerBefore viewController: UIViewController
-    ) -> UIViewController? {
-        let viewController: BottleViewController = viewController as! BottleViewController
-        var index = viewController.index as Int
-        
-        if index <= 0 {
-            return nil
-        }
-        index -= 1
-        return self.makePageContentViewController(with: index)
-    }
-    
-    func pageViewController(
-        _ pageViewController: UIPageViewController,
-        viewControllerAfter viewController: UIViewController
-    ) -> UIViewController? {
-        let viewController: BottleViewController = viewController as! BottleViewController
-        var index = viewController.index as Int
-        let numberOfBottles = self.homeViewModel.pageImages.count
-        
-        if  (index + 1 == numberOfBottles && self.hasBottleInProgress)
-              || index >= numberOfBottles {
-            return nil
-        }
-        
-        index += 1
-        
-        if index == numberOfBottles {
-            print("Add New Jar")
-            
-            // TODO: 팝업 뜨는 시점 수정
-            let createNewBottleViewController: CreateNewBottlePopupViewController
-            = CreateNewBottlePopupViewController()
-            
-            createNewBottleViewController.modalPresentationStyle = .overCurrentContext
-            self.present(createNewBottleViewController, animated: false)
-        }
-        return self.makePageContentViewController(with: index)
-    }
-    // swiftlint:enable force_cast
-}
-
-
-// MARK: - Delegate
-
-extension HomeViewController: UIPageViewControllerDelegate {
-    func pageViewController(
-        _ pageViewController: UIPageViewController,
-        didFinishAnimating finished: Bool,
-        previousViewControllers: [UIViewController],
-        transitionCompleted completed: Bool
-    ) {
-        if completed {
-            if let currentViewController = pageViewController.viewControllers![0]
-                as? BottleViewController {
-                homeViewModel.updatedIndex = currentViewController.index
-            }
-        }
     }
 }


### PR DESCRIPTION
### 반영 내용
issue #21 

- Storyboard 추가 후 TabBarController로 각 화면 연결
    - 각 탭에 NavigationController 추가 (Settings에는 필요 없을 수도 있음)
- HomeViewController에 이제 사용되지 않는 UI요소 및 메서드 삭제

### 추후 작업

- 기존 HomeVC에서 하던 '초기 이미지 구성'을 BottleVC로 이동
    - 진행중인 유리병이 없을 때 BottleVC의 imageView에서 유리병 추가 이미지 띄우고 onTapGesture 추가 
- UI디자인 완료시 BottleVC 레이아웃 변경 및 HomeView에 유리병 라벨 추가
- Tab간 스와이프 이동(-> 논의 후 추가)