### PR TITLE
[feat] 코어데이터 작업 #20

### DIFF
--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		A456657E27CC77A9007CF70A /* Date+Formatted.swift in Sources */ = {isa = PBXBuildFile; fileRef = A456657D27CC77A9007CF70A /* Date+Formatted.swift */; };
 		A491018527D6EDE90012DFDD /* PersistenceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A491018427D6EDE90012DFDD /* PersistenceStore.swift */; };
 		A491018727D6F37C0012DFDD /* NSManagedObject+EntityName.swift in Sources */ = {isa = PBXBuildFile; fileRef = A491018627D6F37C0012DFDD /* NSManagedObject+EntityName.swift */; };
+		A491018D27D7358B0012DFDD /* Bottle+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = A491018C27D7358B0012DFDD /* Bottle+CoreDataClass.swift */; };
+		A491018F27D735920012DFDD /* Note+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = A491018E27D735920012DFDD /* Note+CoreDataClass.swift */; };
 		A499318127BF3A38009FF5A8 /* BottleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A499318027BF3A38009FF5A8 /* BottleViewModel.swift */; };
 		A499318327BF5158009FF5A8 /* BottleImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A499318227BF5158009FF5A8 /* BottleImageView.swift */; };
 		A49931A527BFD20E009FF5A8 /* UIImage+AssetImages.swift in Sources */ = {isa = PBXBuildFile; fileRef = A49931A427BFD20E009FF5A8 /* UIImage+AssetImages.swift */; };
@@ -58,6 +60,8 @@
 		A456657D27CC77A9007CF70A /* Date+Formatted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Formatted.swift"; sourceTree = "<group>"; };
 		A491018427D6EDE90012DFDD /* PersistenceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceStore.swift; sourceTree = "<group>"; };
 		A491018627D6F37C0012DFDD /* NSManagedObject+EntityName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+EntityName.swift"; sourceTree = "<group>"; };
+		A491018C27D7358B0012DFDD /* Bottle+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bottle+CoreDataClass.swift"; sourceTree = "<group>"; };
+		A491018E27D735920012DFDD /* Note+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Note+CoreDataClass.swift"; sourceTree = "<group>"; };
 		A499318027BF3A38009FF5A8 /* BottleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleViewModel.swift; sourceTree = "<group>"; };
 		A499318227BF5158009FF5A8 /* BottleImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleImageView.swift; sourceTree = "<group>"; };
 		A49931A427BFD20E009FF5A8 /* UIImage+AssetImages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+AssetImages.swift"; sourceTree = "<group>"; };
@@ -116,6 +120,8 @@
 		A491016F27D605C40012DFDD /* CoreData */ = {
 			isa = PBXGroup;
 			children = (
+				A491018E27D735920012DFDD /* Note+CoreDataClass.swift */,
+				A491018C27D7358B0012DFDD /* Bottle+CoreDataClass.swift */,
 				A491018427D6EDE90012DFDD /* PersistenceStore.swift */,
 			);
 			path = CoreData;
@@ -394,8 +400,10 @@
 				A8509E6727C85AC900855153 /* PopupTopBar.swift in Sources */,
 				A8E9B2AA27C6070C006403E2 /* CreateNewBottlePopupView.swift in Sources */,
 				A491018527D6EDE90012DFDD /* PersistenceStore.swift in Sources */,
+				A491018D27D7358B0012DFDD /* Bottle+CoreDataClass.swift in Sources */,
 				A8EB5E8B27C8B087005704F2 /* UIButton+Extension.swift in Sources */,
 				A8E9B2A827C606D4006403E2 /* CreateNewBottlePopupViewController.swift in Sources */,
+				A491018F27D735920012DFDD /* Note+CoreDataClass.swift in Sources */,
 				A89CBEE027CC023B005549F6 /* Bottle.swift in Sources */,
 				A8BD833327BE104900E0DE41 /* HomeViewController.swift in Sources */,
 				A499318127BF3A38009FF5A8 /* BottleViewModel.swift in Sources */,

--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -7,8 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A44E901727D5EB130053AC57 /* Happiggy-bank.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = A44E901527D5EB130053AC57 /* Happiggy-bank.xcdatamodeld */; };
 		A456657C27CC66FD007CF70A /* DefaultButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A817430027C112D00016C921 /* DefaultButton.swift */; };
 		A456657E27CC77A9007CF70A /* Date+Formatted.swift in Sources */ = {isa = PBXBuildFile; fileRef = A456657D27CC77A9007CF70A /* Date+Formatted.swift */; };
+		A491018527D6EDE90012DFDD /* PersistenceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A491018427D6EDE90012DFDD /* PersistenceStore.swift */; };
+		A491018727D6F37C0012DFDD /* NSManagedObject+EntityName.swift in Sources */ = {isa = PBXBuildFile; fileRef = A491018627D6F37C0012DFDD /* NSManagedObject+EntityName.swift */; };
 		A499318127BF3A38009FF5A8 /* BottleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A499318027BF3A38009FF5A8 /* BottleViewModel.swift */; };
 		A499318327BF5158009FF5A8 /* BottleImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A499318227BF5158009FF5A8 /* BottleImageView.swift */; };
 		A49931A527BFD20E009FF5A8 /* UIImage+AssetImages.swift in Sources */ = {isa = PBXBuildFile; fileRef = A49931A427BFD20E009FF5A8 /* UIImage+AssetImages.swift */; };
@@ -51,7 +54,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		A44E901627D5EB130053AC57 /* Happigy-bank.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Happigy-bank.xcdatamodel"; sourceTree = "<group>"; };
 		A456657D27CC77A9007CF70A /* Date+Formatted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Formatted.swift"; sourceTree = "<group>"; };
+		A491018427D6EDE90012DFDD /* PersistenceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceStore.swift; sourceTree = "<group>"; };
+		A491018627D6F37C0012DFDD /* NSManagedObject+EntityName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+EntityName.swift"; sourceTree = "<group>"; };
 		A499318027BF3A38009FF5A8 /* BottleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleViewModel.swift; sourceTree = "<group>"; };
 		A499318227BF5158009FF5A8 /* BottleImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleImageView.swift; sourceTree = "<group>"; };
 		A49931A427BFD20E009FF5A8 /* UIImage+AssetImages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+AssetImages.swift"; sourceTree = "<group>"; };
@@ -107,6 +113,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		A491016F27D605C40012DFDD /* CoreData */ = {
+			isa = PBXGroup;
+			children = (
+				A491018427D6EDE90012DFDD /* PersistenceStore.swift */,
+			);
+			path = CoreData;
+			sourceTree = "<group>";
+		};
 		A499317F27BF3A2C009FF5A8 /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
@@ -201,6 +215,7 @@
 				A4CF2C8127C73B42001B01B1 /* UIColor+AssetColors.swift */,
 				A8509E6D27C89A1200855153 /* UIColor+Extension.swift */,
 				A8EB5E8A27C8B087005704F2 /* UIButton+Extension.swift */,
+				A491018627D6F37C0012DFDD /* NSManagedObject+EntityName.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -233,6 +248,7 @@
 		A8FC07C627B3ECF00077A758 /* Happiggy-bank */ = {
 			isa = PBXGroup;
 			children = (
+				A491016F27D605C40012DFDD /* CoreData */,
 				A89CBEDE27CC0233005549F6 /* Model */,
 				A87DCD3727C785D800AB0537 /* Subview */,
 				A499317F27BF3A2C009FF5A8 /* ViewModel */,
@@ -247,6 +263,7 @@
 				A8BD834B27BE347700E0DE41 /* Extensions */,
 				A8FC07D027B3ECF30077A758 /* Assets.xcassets */,
 				A8FC07D527B3ECF30077A758 /* Info.plist */,
+				A44E901527D5EB130053AC57 /* Happiggy-bank.xcdatamodeld */,
 			);
 			path = "Happiggy-bank";
 			sourceTree = "<group>";
@@ -341,7 +358,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if test -d \"/opt/homebrew/bin/\"; then\n  PATH=\"/opt/homebrew/bin/:${PATH}\"\nfi\n\nexport PATH\n\nif which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -363,6 +380,7 @@
 				A4CF2C7C27C71FF5001B01B1 /* CATransition+PopupAnimation.swift in Sources */,
 				A8FC07C827B3ECF00077A758 /* AppDelegate.swift in Sources */,
 				A4CF2C7827C4EBEE001B01B1 /* UIViewController+Popup.swift in Sources */,
+				A491018727D6F37C0012DFDD /* NSManagedObject+EntityName.swift in Sources */,
 				A4CF2C8C27CB6FA9001B01B1 /* NoteTextView.swift in Sources */,
 				A8BD833527BE106C00E0DE41 /* BottleViewController.swift in Sources */,
 				A4CF2C8027C733FE001B01B1 /* ColorButton.swift in Sources */,
@@ -375,12 +393,14 @@
 				A4CF2C5427C48DA1001B01B1 /* NewNotePopupViewController.swift in Sources */,
 				A8509E6727C85AC900855153 /* PopupTopBar.swift in Sources */,
 				A8E9B2AA27C6070C006403E2 /* CreateNewBottlePopupView.swift in Sources */,
+				A491018527D6EDE90012DFDD /* PersistenceStore.swift in Sources */,
 				A8EB5E8B27C8B087005704F2 /* UIButton+Extension.swift in Sources */,
 				A8E9B2A827C606D4006403E2 /* CreateNewBottlePopupViewController.swift in Sources */,
 				A89CBEE027CC023B005549F6 /* Bottle.swift in Sources */,
 				A8BD833327BE104900E0DE41 /* HomeViewController.swift in Sources */,
 				A499318127BF3A38009FF5A8 /* BottleViewModel.swift in Sources */,
 				A89CBEDB27CBDD99005549F6 /* BottleCell.swift in Sources */,
+				A44E901727D5EB130053AC57 /* Happiggy-bank.xcdatamodeld in Sources */,
 				A49931A527BFD20E009FF5A8 /* UIImage+AssetImages.swift in Sources */,
 				A4CF2C7E27C72991001B01B1 /* ColorPalette.swift in Sources */,
 				A8BD833F27BE30B400E0DE41 /* Constants.swift in Sources */,
@@ -626,6 +646,19 @@
 			productName = Then;
 		};
 /* End XCSwiftPackageProductDependency section */
+
+/* Begin XCVersionGroup section */
+		A44E901527D5EB130053AC57 /* Happiggy-bank.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				A44E901627D5EB130053AC57 /* Happigy-bank.xcdatamodel */,
+			);
+			currentVersion = A44E901627D5EB130053AC57 /* Happigy-bank.xcdatamodel */;
+			path = "Happiggy-bank.xcdatamodeld";
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = A8FC07BC27B3ECF00077A758 /* Project object */;
 }

--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,66 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "SourceKitten",
-        "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
-        "state": {
-          "branch": null,
-          "revision": "558628392eb31d37cb251cfe626c53eafd330df6",
-          "version": "0.31.1"
-        }
-      },
-      {
-        "package": "swift-argument-parser",
-        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
-        "state": {
-          "branch": null,
-          "revision": "e394bf350e38cb100b6bc4172834770ede1b7232",
-          "version": "1.0.3"
-        }
-      },
-      {
-        "package": "SwiftLint",
-        "repositoryURL": "https://github.com/realm/SwiftLint.git",
-        "state": {
-          "branch": null,
-          "revision": "9c81e1a93a367db773f50c85229d942d0bb9aeaf",
-          "version": "0.46.3"
-        }
-      },
-      {
-        "package": "SwiftyTextTable",
-        "repositoryURL": "https://github.com/scottrhoyt/SwiftyTextTable.git",
-        "state": {
-          "branch": null,
-          "revision": "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
-          "version": "0.9.0"
-        }
-      },
-      {
-        "package": "SWXMLHash",
-        "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
-        "state": {
-          "branch": null,
-          "revision": "9183170d20857753d4f331b0ca63f73c60764bf3",
-          "version": "5.0.2"
-        }
-      },
-      {
         "package": "Then",
         "repositoryURL": "https://github.com/devxoul/Then.git",
         "state": {
           "branch": null,
           "revision": "e421a7b3440a271834337694e6050133a3958bc7",
           "version": "2.7.0"
-        }
-      },
-      {
-        "package": "Yams",
-        "repositoryURL": "https://github.com/jpsim/Yams.git",
-        "state": {
-          "branch": null,
-          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-          "version": "4.0.6"
         }
       }
     ]

--- a/Happiggy-bank/Happiggy-bank/AppDelegate.swift
+++ b/Happiggy-bank/Happiggy-bank/AppDelegate.swift
@@ -5,6 +5,7 @@
 //  Created by 권은빈 on 2022/02/09.
 //
 
+import CoreData
 import UIKit
 
 @main
@@ -30,7 +31,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
+    
 
 }
 

--- a/Happiggy-bank/Happiggy-bank/CoreData/Bottle+CoreDataClass.swift
+++ b/Happiggy-bank/Happiggy-bank/CoreData/Bottle+CoreDataClass.swift
@@ -1,0 +1,86 @@
+//
+//  Bottle+CoreDataClass.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/03/07.
+//
+//
+
+import CoreData
+import Foundation
+
+import Then
+
+@objc(Bottle)
+/// 코어데이터의 저금통 엔티티
+public class Bottle: NSManagedObject {
+
+    // MARK: - Static functions
+    
+    /// sortDescriptor 를 설정하지 않으면 (생성 날짜) 최신순으로 정렬
+    static func fetchRequest(
+        predicate: NSPredicate,
+        sortDescriptor: [NSSortDescriptor] = [NSSortDescriptor(
+            key: "startDate_",
+            ascending: false
+        )]
+    ) -> NSFetchRequest<Bottle> {
+        NSFetchRequest<Bottle>(entityName: NSManagedObject.entityName).then {
+            $0.predicate = predicate
+            $0.sortDescriptors = sortDescriptor
+        }
+    }
+    
+    /// 개봉/미개봉된 저금통을 각각 불러올 수 있으며 sortDescriptor 를 설정하지 않으면 (생성 날짜) 최신순으로 정렬
+    /// 홈뷰 -> 미개봉 저금통
+    /// 저금통 리스트 -> 개봉 저금통
+    static func fetchRequest(
+        isOpen: Bool,
+        sortDescriptor: [NSSortDescriptor] = [NSSortDescriptor(
+            key: "startDate_",
+            ascending: false
+        )]
+    ) -> NSFetchRequest<Bottle> {
+        NSFetchRequest<Bottle>(entityName: NSManagedObject.entityName).then {
+            $0.sortDescriptors = sortDescriptor
+            $0.predicate = NSPredicate(format: "isOpen_ == %@", argumentArray: [isOpen])
+            $0.sortDescriptors = sortDescriptor
+        }
+    }
+    
+    
+    // MARK: - Init(s)
+    
+    /// 주어진 제목, 시작날짜, 종료날짜를 갖는 저금통 인스턴스를 코어데이터에 새로 생성함
+    /// 아이디는 자체 생성, isOpen 과 hasFixedTitle 은 기본 false 로 설정
+    /// 저장은 별도로 해야함
+    convenience init(title: String, startDate: Date, endDate: Date) {
+        self.init(context: PersistenceStore.shared.context)
+        self.id_ = UUID()
+        self.title_ = title
+        self.startDate_ = startDate
+        self.endDate_ = endDate
+    }
+    
+    
+    // MARK: - (nil-coalesced) Properties
+    
+    /// 고유 아이디
+    public var id: UUID { id_ ?? UUID() }
+    
+    /// 제목
+    var title: String {
+        get { title_ ?? StringLiteral.title}
+        set { title_ = newValue }
+    }
+    
+    /// 시작 날짜
+    var startDate: Date { startDate_ ?? Date() }
+    
+    /// 개봉 예정 날짜
+    var endDate: Date { endDate_ ?? Date() }
+    
+    /// 해당 저금통에 들어있는 쪽지들의 Set
+    var notes: Set<Note> { notes_ as? Set<Note> ?? [] }
+    
+}

--- a/Happiggy-bank/Happiggy-bank/CoreData/Note+CoreDataClass.swift
+++ b/Happiggy-bank/Happiggy-bank/CoreData/Note+CoreDataClass.swift
@@ -1,0 +1,47 @@
+//
+//  Note+CoreDataClass.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/03/07.
+//
+//
+
+import CoreData
+import Foundation
+
+@objc(Note)
+/// 코어데이터의 쪽지 엔티티
+public class Note: NSManagedObject {
+    
+    // MARK: Init(s)
+    
+    /// 주어진 날짜, 색깔, 내용을 갖는 쪽지 인스턴스를 코어데이터에 새로 생성하고 저금통과도 연결함
+    /// 아이디는 자체적으로 생성하고 isOpen 은 자동으로 false 로 설정
+    /// 저장은 별도로 해야 함
+    convenience init(date: Date, color: String, content: String, bottle: Bottle) {
+        self.init(context: PersistenceStore.shared.context)
+        self.id_ = UUID()
+        self.date_ = date
+        self.color_ = color
+        self.content_ = content
+        bottle.addToNotes_(self)
+    }
+    
+    
+    // MARK: - (nil-coalesced) Properties
+    
+    /// 고유 아이디
+    public var id: UUID { self.id_ ?? UUID() }
+    
+    /// 생성 날짜
+    var date: Date { self.date_ ?? Date() }
+    
+    /// 내용
+    var content: String { self.content_ ?? StringLiteral.content }
+    
+    /// 색깔
+    var color: String { self.color_ ?? NoteColor.default }
+    
+    /// 담겨있는 저금통
+    var bottle: Bottle { self.bottle_ ?? Bottle() }
+}

--- a/Happiggy-bank/Happiggy-bank/CoreData/PersistenceStore.swift
+++ b/Happiggy-bank/Happiggy-bank/CoreData/PersistenceStore.swift
@@ -1,0 +1,120 @@
+//
+//  PersistenceStore.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/03/08.
+//
+
+import CoreData
+import UIKit
+
+import Then
+
+/// 싱글턴 패턴을 사용해 앱 전체에서 하나의 Persistence Container 를 통해 엔티티 인스턴스를  저장, 삭제하도록 함
+class PersistenceStore {
+    
+    // MARK: - Core Data Stack
+    
+    /// 앱 전체에서 공유되는 단일 PersistenceStore
+    static var shared: PersistenceStore = {
+        PersistenceStore(name: StringLiteral.sharedPersistenceStoreName)
+    }()
+    
+    /// persistence container 의 viewContext 에 접근하기 위한 syntactic sugar
+    private(set) lazy var context: NSManagedObjectContext = {
+        self.persistentContainer.viewContext
+    }()
+    
+    private let persistentContainer: NSPersistentContainer
+    
+    
+    // MARK: - Init(s)
+    init(name: String) {
+        /*
+         The persistent container for the application. This implementation
+         creates and returns a container, having loaded the store for the
+         application to it. This property is optional since there are legitimate
+         error conditions that could cause the creation of the store to fail.
+         */
+        self.persistentContainer = NSPersistentContainer(name: name).then {
+            $0.loadPersistentStores(completionHandler: { _, error in
+                if let error = error as NSError? {
+                    // Replace this implementation with code to handle the error appropriately.
+                    // fatalError() causes the application to generate a crash log and terminate.
+                    // You should not use this function in a shipping application,
+                    // although it may be useful during development.
+                    
+                    /*
+                     Typical reasons for an error here include:
+                     * The parent directory does not exist, cannot be created, or disallows writing.
+                     * The persistent store is not accessible,
+                     * due to permissions or data protection when the device is locked.
+                     * The device is out of space.
+                     * The store could not be migrated to the current model version.
+                     Check the error message to determine what the actual problem was.
+                     */
+                    fatalError("Unresolved error \(error), \(error.userInfo)")
+                }
+            })
+        }
+    }
+    
+    
+    // MARK: - Core Data Fetching support
+    
+    /// 코어데이터를 불러오기 위한 syntactic sugar
+    func fetch<T: NSManagedObject>(request: NSFetchRequest<T>) -> [T] {
+        do {
+            let items = try self.context.fetch(request)
+            return items
+        } catch {
+            print(error.localizedDescription)
+            return []
+        }
+    }
+    
+    
+    // MARK: - Core Data Saving support
+    
+    /// 현재 context 를 저장, 에러가 발생하면 설정한 에러 메시지(기본은 에러 이름)를 출력함
+    func save(errorMessage: String? = nil) {
+        if self.context.hasChanges {
+            do {
+                try self.context.save()
+            } catch {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate.
+                // You should not use this function in a shipping application,
+                // although it may be useful during development.
+                let nserror = error as NSError
+                if let errorMessage = errorMessage {
+                    print("\(errorMessage)+\(nserror.localizedDescription)+\(nserror.userInfo)")
+                } else {
+                    print("\(nserror.localizedDescription), \(nserror.userInfo)")
+                }
+            }
+        }
+    }
+    
+    
+    // MARK: - Core Data Deleting support
+    /// TODO: 개발 단계 편의를 위한 메서드로 추후 삭제
+    
+    /// 엔티티 인스턴스 삭제
+    func delete(_ object: NSManagedObject) {
+        self.context.delete(object)
+        self.save()
+    }
+    
+    /// 엔티티의 모든 인스턴스 삭제
+    func deleteAll<T: NSManagedObject>(_ type: T.Type) {
+        let request = type.fetchRequest()
+        let delete = NSBatchDeleteRequest(fetchRequest: request)
+        
+        do {
+            try self.context.execute(delete)
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/Extensions/NSManagedObject+EntityName.swift
+++ b/Happiggy-bank/Happiggy-bank/Extensions/NSManagedObject+EntityName.swift
@@ -1,0 +1,17 @@
+//
+//  NSManagedObject+EntityName.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/03/08.
+//
+
+import Foundation
+import CoreData
+
+extension NSManagedObject {
+    
+    /// 휴먼 에러 방지를 위한 entityName 생성 프로퍼티
+    static var entityName: String {
+        String(describing: self).components(separatedBy: ".").last!
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/Happiggy-bank.xcdatamodeld/Happigy-bank.xcdatamodel/contents
+++ b/Happiggy-bank/Happiggy-bank/Happiggy-bank.xcdatamodeld/Happigy-bank.xcdatamodel/contents
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19206" systemVersion="20G165" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <elements/>
+</model>

--- a/Happiggy-bank/Happiggy-bank/Happiggy-bank.xcdatamodeld/Happigy-bank.xcdatamodel/contents
+++ b/Happiggy-bank/Happiggy-bank/Happiggy-bank.xcdatamodeld/Happigy-bank.xcdatamodel/contents
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19206" systemVersion="20G165" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
-    <elements/>
+    <entity name="Bottle" representedClassName="Bottle" syncable="YES" codeGenerationType="category">
+        <attribute name="endDate_" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="hasFixedTitle" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="id_" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="isOpen" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="startDate_" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="title_" optional="YES" attributeType="String"/>
+        <relationship name="notes_" optional="YES" toMany="YES" maxCount="365" deletionRule="Cascade" destinationEntity="Note" inverseName="bottle_" inverseEntity="Note"/>
+    </entity>
+    <entity name="Note" representedClassName="Note" syncable="YES" codeGenerationType="category">
+        <attribute name="color_" optional="YES" attributeType="String"/>
+        <attribute name="content_" optional="YES" attributeType="String" minValueString="1" maxValueString="100"/>
+        <attribute name="date_" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id_" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="isOpen" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <relationship name="bottle_" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Bottle" inverseName="notes_" inverseEntity="Bottle"/>
+    </entity>
+    <elements>
+        <element name="Bottle" positionX="170.34765625" positionY="-325.72265625" width="128" height="148"/>
+        <element name="Note" positionX="179.48046875" positionY="-52.40625" width="128" height="133"/>
+    </elements>
 </model>

--- a/Happiggy-bank/Happiggy-bank/Model/Bottle.swift
+++ b/Happiggy-bank/Happiggy-bank/Model/Bottle.swift
@@ -7,10 +7,10 @@
 
 import Foundation
 
-// TODO: Bottle Model 수정 및 기간 계산 로직 추가
+// FIXME: 엔티티 Bottle 과 겹쳐서 주석 처리
 /// 유리병 데이터 모델
-struct Bottle {
-    var id: Int
-    var title: String
-    var date: String
-}
+//struct Bottle {
+//    var id: Int
+//    var title: String
+//    var date: String
+//}

--- a/Happiggy-bank/Happiggy-bank/SceneDelegate.swift
+++ b/Happiggy-bank/Happiggy-bank/SceneDelegate.swift
@@ -50,6 +50,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
+        
+        // Save changes in the application's managed object context when the application transitions to the background.
+        PersistenceStore.shared.save()
     }
 
 

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -580,3 +580,51 @@ extension BottleCell {
         static let dateLabelText: Int = 0xA19491
     }
 }
+
+extension Bottle {
+    
+    /// Bottle 엔티티에서 설정하는 문자열
+    enum StringLiteral {
+        
+        
+        /// 엔티티 이름
+        static let entityName = "Bottle"
+        
+        /// 제목 디폴트 값: "?"
+        static let title = "?"
+    }
+    
+}
+
+/// 쪽지 색상들을 모아둔 enum 으로 상황별로 기본 문자열에 이하 문자열을 접두사/접미사로 붙여서 불러올 애셋 이름을 완성
+/// e.g MainViewNote + NoteColors.white
+enum NoteColor {
+    
+    /// 기본 쪽지 색깔
+    static let `default` = NoteColor.white
+    
+    /// 흰색 쪽지
+    static let white = "white"
+    
+    /// 분홍 쪽지
+    static let pink = "pink"
+    
+    /// 보라 쪽지
+    static let purple = "purple"
+    
+    /// 노랑 쪽지
+    static let yellow = "yellow"
+    
+    /// 연두 쪽지
+    static let green = "green"
+}
+
+extension PersistenceStore {
+    
+    /// Persistence Store 에서 사용되는 문자열들
+    enum StringLiteral {
+        
+        /// 공유 persistence store 의 이름 : "Happiggy-bank"
+        static let sharedPersistenceStoreName = "Happiggy-bank"
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -585,13 +585,20 @@ extension Bottle {
     
     /// Bottle 엔티티에서 설정하는 문자열
     enum StringLiteral {
-        
-        
-        /// 엔티티 이름
-        static let entityName = "Bottle"
-        
+
         /// 제목 디폴트 값: "?"
         static let title = "?"
+    }
+    
+}
+
+extension Note {
+    
+    /// Note 엔티티에서 설정하는 문자열
+    enum StringLiteral {
+
+        /// 내용 디폴트 값: "?"
+        static let content = "?"
     }
     
 }

--- a/Happiggy-bank/Happiggy-bank/ViewController/BottleListViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/BottleListViewController.swift
@@ -20,7 +20,9 @@ final class BottleListViewController: UIViewController {
         var bottles = [Bottle]()
         
         for index in 0...3 {
-            let bottle = Bottle(id: index, title: "bottle \(index)", date: "2022.01.01 ~ 2022.01.31")
+            // FIXME: 코어데이터 엔티티 생성하면서 주석 처리 및 밑에 일단 임시 인스턴스 생성
+//            let bottle = Bottle(id: index, title: "bottle \(index)", date: "2022.01.01 ~ 2022.01.31")
+            let bottle = Bottle(title: "유리병 \(index + 1)", startDate: Date(), endDate: Date())
             bottles.append(bottle)
         }
         
@@ -136,7 +138,8 @@ extension BottleListViewController: UITableViewDataSource {
         
         resetReusableCellAttribute(cell)
         cell.titleLabel.text = bottle.title
-        cell.dateLabel.text = bottle.date
+        // FIXME: 코어데이터 엔티티 생성하면서 주석 처리
+//        cell.dateLabel.text = bottle.startDate.description
         
         return cell
     }


### PR DESCRIPTION
## 작업 내용
- 이슈 #20 

### PersistenceStore 
- 코어데이터 저장, 호출을 담당하는 인스턴스 생성
  - 싱글턴으로 앱 전체에서 하나의 persistence container 공유 
- 호출, 저장, 삭제를 위한 메서드 추가
  -  삭제는 작업 편의를 위해 생성했고 추후 삭제 예정


<br>

### 데이터 모델
- 저금통-쪽지 관계 1:N 으로 설정, 저금통 삭제 시 쪽지도 함께 삭제되도록 함
- 불리언 프로퍼티들은 디폴트 값 다 false 로 주고 논옵셔널하게 만듦

<br>

### Bottle, Note Class 공통
- 객체 생성 시 편의를 위한 convenience init 추가 (저장은 별도) 
- 편의를 위해 옵셔널한 프로퍼티들 연산 프로퍼티로 닐 코알리싱
  - 값이 수정될 수 있는 불리언들, 저금통 제목 외에는 다 get-only

<br>

### Bottle Class
- 범용성 있는 fetchRequest 를 만들어주는 메서드와 열린/닫힌 저금통에 대한 fetchRequest 를 생성하는 메서드 추가
  - 각각 저금통 리스트, 홈뷰에서 사용할 수 있도록

<br>

## 추후 작업
- 에러 처리 관련 작업
- 코어데이터의 _ 붙은 프로퍼티들 private 하게 만들어버리기?
- 저금통 진행 정도 같은 프로퍼티를 Bottle Class 안에 선언할까 고민하다가 작업이 너무 늦어지는 것 같아 일단 패스했습니당
- 제가 호출, 저장, 삭제 다 잘 되는지 확인하긴 했는데 혹시 문제 있을 수도 있으니까 문제 생기면 바로 알려주세요...!