### PR TITLE
[feat] 쪽지 추가를 위한 뷰 컨트롤러들 생성 및 연결 #26

### DIFF
--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -18,6 +18,10 @@
 		A499318327BF5158009FF5A8 /* BottleImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A499318227BF5158009FF5A8 /* BottleImageView.swift */; };
 		A49931A527BFD20E009FF5A8 /* UIImage+AssetImages.swift in Sources */ = {isa = PBXBuildFile; fileRef = A49931A427BFD20E009FF5A8 /* UIImage+AssetImages.swift */; };
 		A4B285FD27D8A060008769EB /* Calendar+Duration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B285FC27D8A060008769EB /* Calendar+Duration.swift */; };
+		A4B2860527D9A546008769EB /* NewNoteDatePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B2860427D9A546008769EB /* NewNoteDatePickerViewController.swift */; };
+		A4B2860727D9A55C008769EB /* NewNoteColorPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B2860627D9A55C008769EB /* NewNoteColorPickerViewController.swift */; };
+		A4B2860927D9A56A008769EB /* NewNoteTextViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B2860827D9A56A008769EB /* NewNoteTextViewController.swift */; };
+		A4B2860B27D9B434008769EB /* UIViewController+FadeOut.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B2860A27D9B434008769EB /* UIViewController+FadeOut.swift */; };
 		A4CF2C5427C48DA1001B01B1 /* NewNotePopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CF2C5327C48DA1001B01B1 /* NewNotePopupViewController.swift */; };
 		A4CF2C7827C4EBEE001B01B1 /* UIViewController+Popup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CF2C7727C4EBEE001B01B1 /* UIViewController+Popup.swift */; };
 		A4CF2C7A27C61867001B01B1 /* NewNotePopupTopBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CF2C7927C61867001B01B1 /* NewNotePopupTopBar.swift */; };
@@ -66,6 +70,10 @@
 		A499318227BF5158009FF5A8 /* BottleImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleImageView.swift; sourceTree = "<group>"; };
 		A49931A427BFD20E009FF5A8 /* UIImage+AssetImages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+AssetImages.swift"; sourceTree = "<group>"; };
 		A4B285FC27D8A060008769EB /* Calendar+Duration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Calendar+Duration.swift"; sourceTree = "<group>"; };
+		A4B2860427D9A546008769EB /* NewNoteDatePickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNoteDatePickerViewController.swift; sourceTree = "<group>"; };
+		A4B2860627D9A55C008769EB /* NewNoteColorPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNoteColorPickerViewController.swift; sourceTree = "<group>"; };
+		A4B2860827D9A56A008769EB /* NewNoteTextViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNoteTextViewController.swift; sourceTree = "<group>"; };
+		A4B2860A27D9B434008769EB /* UIViewController+FadeOut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+FadeOut.swift"; sourceTree = "<group>"; };
 		A4CF2C5327C48DA1001B01B1 /* NewNotePopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNotePopupViewController.swift; sourceTree = "<group>"; };
 		A4CF2C7727C4EBEE001B01B1 /* UIViewController+Popup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Popup.swift"; sourceTree = "<group>"; };
 		A4CF2C7927C61867001B01B1 /* NewNotePopupTopBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNotePopupTopBar.swift; sourceTree = "<group>"; };
@@ -148,13 +156,6 @@
 			path = Subview;
 			sourceTree = "<group>";
 		};
-		A89CBEDE27CC0233005549F6 /* Model */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Model;
-			sourceTree = "<group>";
-		};
 		A8BD834227BE32EB00E0DE41 /* Button */ = {
 			isa = PBXGroup;
 			children = (
@@ -173,6 +174,9 @@
 				A4CF2C5327C48DA1001B01B1 /* NewNotePopupViewController.swift */,
 				A8E9B2A727C606D4006403E2 /* CreateNewBottlePopupViewController.swift */,
 				A89CBEDC27CBDEA2005549F6 /* BottleListViewController.swift */,
+				A4B2860427D9A546008769EB /* NewNoteDatePickerViewController.swift */,
+				A4B2860627D9A55C008769EB /* NewNoteColorPickerViewController.swift */,
+				A4B2860827D9A56A008769EB /* NewNoteTextViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -213,6 +217,7 @@
 			children = (
 				A4CF2C8F27CBA66F001B01B1 /* NSNotificaion.Name+CustomNotifications.swift */,
 				A4CF2C7B27C71FF5001B01B1 /* CATransition+PopupAnimation.swift */,
+				A4B2860A27D9B434008769EB /* UIViewController+FadeOut.swift */,
 				A49931A427BFD20E009FF5A8 /* UIImage+AssetImages.swift */,
 				A456657D27CC77A9007CF70A /* Date+Formatted.swift */,
 				A4CF2C7727C4EBEE001B01B1 /* UIViewController+Popup.swift */,
@@ -255,7 +260,6 @@
 			isa = PBXGroup;
 			children = (
 				A491016F27D605C40012DFDD /* CoreData */,
-				A89CBEDE27CC0233005549F6 /* Model */,
 				A87DCD3727C785D800AB0537 /* Subview */,
 				A499317F27BF3A2C009FF5A8 /* ViewModel */,
 				A8FC07C727B3ECF00077A758 /* AppDelegate.swift */,
@@ -391,6 +395,8 @@
 				A8BD833527BE106C00E0DE41 /* BottleViewController.swift in Sources */,
 				A4CF2C8027C733FE001B01B1 /* ColorButton.swift in Sources */,
 				A4CF2C8227C73B42001B01B1 /* UIColor+AssetColors.swift in Sources */,
+				A4B2860B27D9B434008769EB /* UIViewController+FadeOut.swift in Sources */,
+				A4B2860927D9A56A008769EB /* NewNoteTextViewController.swift in Sources */,
 				A8FC07CA27B3ECF00077A758 /* SceneDelegate.swift in Sources */,
 				A456657E27CC77A9007CF70A /* Date+Formatted.swift in Sources */,
 				A8509E6C27C8991100855153 /* PopupTextInputField.swift in Sources */,
@@ -400,11 +406,13 @@
 				A8509E6727C85AC900855153 /* PopupTopBar.swift in Sources */,
 				A4B285FD27D8A060008769EB /* Calendar+Duration.swift in Sources */,
 				A8E9B2AA27C6070C006403E2 /* CreateNewBottlePopupView.swift in Sources */,
+				A4B2860527D9A546008769EB /* NewNoteDatePickerViewController.swift in Sources */,
 				A491018527D6EDE90012DFDD /* PersistenceStore.swift in Sources */,
 				A491018D27D7358B0012DFDD /* Bottle+CoreDataClass.swift in Sources */,
 				A8EB5E8B27C8B087005704F2 /* UIButton+Extension.swift in Sources */,
 				A8E9B2A827C606D4006403E2 /* CreateNewBottlePopupViewController.swift in Sources */,
 				A491018F27D735920012DFDD /* Note+CoreDataClass.swift in Sources */,
+				A4B2860727D9A55C008769EB /* NewNoteColorPickerViewController.swift in Sources */,
 				A8BD833327BE104900E0DE41 /* HomeViewController.swift in Sources */,
 				A499318127BF3A38009FF5A8 /* BottleViewModel.swift in Sources */,
 				A89CBEDB27CBDD99005549F6 /* BottleCell.swift in Sources */,

--- a/Happiggy-bank/Happiggy-bank/Extensions/CATransition+PopupAnimation.swift
+++ b/Happiggy-bank/Happiggy-bank/Extensions/CATransition+PopupAnimation.swift
@@ -10,9 +10,9 @@ import UIKit
 extension CATransition {
     
     /// 뷰가 사라질 때 페이드 아웃 효과를 나타냄
-    func fadeTransition() -> CATransition {
+    static func fadeTransition() -> CATransition {
         let transition = CATransition()
-        transition.duration = 0.2
+        transition.duration = self.transitionDuration
         transition.type = CATransitionType.fade
         transition.subtype = CATransitionSubtype.fromRight
 

--- a/Happiggy-bank/Happiggy-bank/Extensions/UIViewController+FadeOut.swift
+++ b/Happiggy-bank/Happiggy-bank/Extensions/UIViewController+FadeOut.swift
@@ -1,0 +1,19 @@
+//
+//  UIViewController+FadeOut.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/03/10.
+//
+
+import UIKit
+
+extension UIViewController {
+    
+    /// 뷰가 사라질 때 페이드아웃 효과를 주기 위한 syntactic sugar
+    func fadeOut() {
+        guard let window = self.view.window
+        else { return }
+        
+        window.layer.add(CATransition.fadeTransition(), forKey: kCATransition)
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -153,10 +153,133 @@
             </objects>
             <point key="canvasLocation" x="1738" y="868"/>
         </scene>
+        <!--New Note Date Picker View Controller-->
+        <scene sceneID="b0a-93-uoW">
+            <objects>
+                <viewController modalTransitionStyle="crossDissolve" modalPresentationStyle="fullScreen" id="moi-e1-3hQ" customClass="NewNoteDatePickerViewController" customModule="Happiggy_bank" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="sBx-5w-9Me">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="x5u-uo-squ">
+                                <rect key="frame" x="0.0" y="44" width="375" height="44"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                <items>
+                                    <navigationItem title="날짜 선택" id="Dya-aA-mUT">
+                                        <barButtonItem key="leftBarButtonItem" title="Cancel" image="xmark" catalog="system" id="Phw-2k-dd2">
+                                            <connections>
+                                                <action selector="cancelButtonDidTap:" destination="moi-e1-3hQ" id="u3a-bF-N2P"/>
+                                            </connections>
+                                        </barButtonItem>
+                                        <barButtonItem key="rightBarButtonItem" title="Next" image="chevron.right" catalog="system" id="gJA-eJ-60b">
+                                            <connections>
+                                                <action selector="nextButtonDidTap:" destination="moi-e1-3hQ" id="349-pU-kF0"/>
+                                            </connections>
+                                        </barButtonItem>
+                                    </navigationItem>
+                                </items>
+                            </navigationBar>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="Xam-7g-OPV"/>
+                        <color key="backgroundColor" systemColor="systemTealColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="KqF-zH-uxO"/>
+                    <size key="freeformSize" width="375" height="812"/>
+                    <connections>
+                        <outlet property="navigationBar" destination="x5u-uo-squ" id="TZk-W8-eWp"/>
+                        <segue destination="g5l-hv-0de" kind="presentation" identifier="presentNewNoteColorPicker" id="MBC-MA-0pk"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="4WR-mG-PvL" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1151" y="3010"/>
+        </scene>
+        <!--New Note Text View Controller-->
+        <scene sceneID="f85-ew-CtQ">
+            <objects>
+                <viewController modalTransitionStyle="crossDissolve" modalPresentationStyle="overFullScreen" id="FuI-qc-1fd" customClass="NewNoteTextViewController" customModule="Happiggy_bank" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="1PQ-Bn-66w">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Rms-YT-wWN">
+                                <rect key="frame" x="0.0" y="44" width="375" height="44"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                <items>
+                                    <navigationItem title="쪽지 작성" id="rjR-Ha-zae">
+                                        <barButtonItem key="leftBarButtonItem" title="Cancel" image="xmark" catalog="system" id="zKb-tM-XLc">
+                                            <connections>
+                                                <action selector="cancelButtonDidTap:" destination="FuI-qc-1fd" id="KZ1-Lf-r9d"/>
+                                            </connections>
+                                        </barButtonItem>
+                                        <barButtonItem key="rightBarButtonItem" title="Save" image="checkmark" catalog="system" id="HRF-q1-cdw">
+                                            <connections>
+                                                <action selector="saveButtonDidTap:" destination="FuI-qc-1fd" id="syQ-nR-mdU"/>
+                                            </connections>
+                                        </barButtonItem>
+                                    </navigationItem>
+                                </items>
+                            </navigationBar>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="bn6-rM-p0H"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="OdQ-rH-b8B"/>
+                    <size key="freeformSize" width="375" height="812"/>
+                    <connections>
+                        <outlet property="navigationBar" destination="Rms-YT-wWN" id="i1C-it-zIw"/>
+                        <segue destination="rAE-WY-Wyc" kind="unwind" identifier="unwindToBotteView" animates="NO" unwindAction="unwindCallDidArriveWithSegue:" id="S89-mV-zbI"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="xbT-jH-6dB" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1151" y="4482"/>
+        </scene>
+        <!--New Note Color Picker View Controller-->
+        <scene sceneID="bf8-Au-5CK">
+            <objects>
+                <viewController modalTransitionStyle="crossDissolve" modalPresentationStyle="overFullScreen" id="g5l-hv-0de" customClass="NewNoteColorPickerViewController" customModule="Happiggy_bank" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="t95-o1-XLO">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MqT-Ah-3Uq">
+                                <rect key="frame" x="0.0" y="44" width="375" height="44"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                <items>
+                                    <navigationItem title="색깔 선택" id="DM1-Z5-JBN">
+                                        <barButtonItem key="leftBarButtonItem" title="Back" image="chevron.left" catalog="system" id="CIr-tB-YaV">
+                                            <connections>
+                                                <action selector="backButtonDidTap:" destination="g5l-hv-0de" id="pas-6F-NnN"/>
+                                            </connections>
+                                        </barButtonItem>
+                                        <barButtonItem key="rightBarButtonItem" title="Next" image="chevron.right" catalog="system" id="WwR-ae-CZJ">
+                                            <connections>
+                                                <action selector="nextButtonDidTap:" destination="g5l-hv-0de" id="Gki-AE-0g2"/>
+                                            </connections>
+                                        </barButtonItem>
+                                    </navigationItem>
+                                </items>
+                            </navigationBar>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="0NK-Mm-KBY"/>
+                        <color key="backgroundColor" systemColor="systemOrangeColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="7jK-EQ-u4a"/>
+                    <size key="freeformSize" width="375" height="812"/>
+                    <connections>
+                        <outlet property="navigationBar" destination="MqT-Ah-3Uq" id="yBg-1F-rGN"/>
+                        <segue destination="FuI-qc-1fd" kind="presentation" identifier="presentNewNoteTextView" id="JPj-QX-xRf"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="MZX-4l-0Ef" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1151" y="3742"/>
+        </scene>
         <!--Bottle View Controller-->
         <scene sceneID="p7l-16-uR7">
             <objects>
-                <viewController id="FVx-vN-7Xe" customClass="BottleViewController" customModule="Happiggy_bank" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController modalTransitionStyle="crossDissolve" modalPresentationStyle="fullScreen" id="FVx-vN-7Xe" customClass="BottleViewController" customModule="Happiggy_bank" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="jBg-oD-Piv">
                         <rect key="frame" x="0.0" y="0.0" width="327" height="440"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -181,9 +304,11 @@
                     </view>
                     <connections>
                         <outlet property="imageView" destination="aPw-QS-DfD" id="8ju-QE-j4a"/>
+                        <segue destination="moi-e1-3hQ" kind="presentation" identifier="presentNewNoteDatePicker" id="71M-g6-wMS"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4hG-r2-cSC" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <exit id="rAE-WY-Wyc" userLabel="Exit" sceneMemberID="exit"/>
                 <tapGestureRecognizer id="gEH-ha-I0H">
                     <connections>
                         <action selector="bottleDidTap:" destination="FVx-vN-7Xe" id="mVI-j8-MCV"/>
@@ -194,11 +319,21 @@
         </scene>
     </scenes>
     <resources>
+        <image name="checkmark" catalog="system" width="128" height="114"/>
+        <image name="chevron.left" catalog="system" width="96" height="128"/>
+        <image name="chevron.right" catalog="system" width="96" height="128"/>
+        <image name="xmark" catalog="system" width="128" height="113"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGray5Color">
             <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemOrangeColor">
+            <color red="1" green="0.58431372549019611" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemTealColor">
+            <color red="0.18823529411764706" green="0.69019607843137254" blue="0.7803921568627451" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+// swiftlint:disable file_length
 extension HomeViewController {
     
     /// HomeViewController 에서  설정하는 layout 에 적용할 상수값들을 모아놓은 enum
@@ -35,13 +36,6 @@ extension HomeViewController {
         
         /// list Button의 앞쪽 패딩
         static let listButtonLeadingPadding: CGFloat = 88
-    }
-    
-    /// HomeViewController 에서 사용하는 문자열
-    enum StringLiteral {
-        
-        /// "showBottleView" segue identifier 
-        static let showBottleViewIdentifier = "showBottleView"
     }
 }
 
@@ -641,4 +635,29 @@ extension PersistenceStore {
         /// 공유 persistence store 의 이름 : "Happiggy-bank"
         static let sharedPersistenceStoreName = "Happiggy-bank"
     }
+}
+
+/// 스토리보드에서 사용하는 segue identifier 들
+enum SegueIdentifier {
+    
+    /// 홈 뷰컨트롤러에서 보틀뷰 컨트롤러를 띄울 때 사용
+    static let showBottleView = "showBottleView"
+    
+    /// 보틀뷰 컨트롤러에서 새 쪽지 날짜 피커뷰 컨트롤러를 띄울 때 사용
+    static let presentNewNoteDatePicker = "presentNewNoteDatePicker"
+    
+    /// 새 쪽지 날짜 피커에서 색깔 피커를 띄울 때 사용
+    static let presentNewNoteColorPicker = "presentNewNoteColorPicker"
+    
+    /// 색깔 피커에서 새 쪽지 작성뷰 컨트롤러를 띄울 때 사용
+    static let presentNewNoteTextView = "presentNewNoteTextView"
+    
+    /// 쪽지 작성뷰 컨트롤러에서 보틀뷰 컨트롤러로 돌아갈 때 사용
+    static let unwindToBotteView = "unwindToBotteView"
+}
+
+extension CATransition {
+    
+    /// 애니메이션 지속 시간
+    static let transitionDuration: CFTimeInterval = 0.2
 }

--- a/Happiggy-bank/Happiggy-bank/ViewController/BottleViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/BottleViewController.swift
@@ -7,8 +7,6 @@
 
 import UIKit
 
-import Then
-
 // TODO: 진행중인 유리병 있는지 없는지에 따라 초기 화면 구성 및 동작 수행 필요
 /// 각 bottle 의 뷰를 관리하는 컨트롤러
 final class BottleViewController: UIViewController {
@@ -30,7 +28,6 @@ final class BottleViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.addObservers()
-        self.view.backgroundColor = .systemGray
         configureBottleImage()
     }
     
@@ -52,14 +49,21 @@ final class BottleViewController: UIViewController {
             print("show some opening animation")
             return
         }
-        if bottle.hasEmptyDate {
+        if !bottle.hasEmptyDate {
             print("show some alert that no notes are writable")
             return
         }
-        if !bottle.hasEmptyDate {
-            print("show add note popup")
+        if bottle.hasEmptyDate {
+            /// 날짜 피커 띄우기
+            self.performSegue(
+                withIdentifier: SegueIdentifier.presentNewNoteDatePicker,
+                sender: sender
+            )
         }
     }
+    
+    /// 현재 뷰 컨트롤러로 unwind 하라는 호출을 받았을 때 실행되는 액션메서드
+    @IBAction func unwindCallDidArrive(segue: UIStoryboardSegue) {}
     
     
     // MARK: - @objc

--- a/Happiggy-bank/Happiggy-bank/ViewController/HomeViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/HomeViewController.swift
@@ -43,7 +43,7 @@ final class HomeViewController: UIViewController {
     // MARK: - Navigation
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if segue.identifier == StringLiteral.showBottleViewIdentifier {
+        if segue.identifier == SegueIdentifier.showBottleView {
             guard let bottleViewController = segue.destination as? BottleViewController
             else { return }
             

--- a/Happiggy-bank/Happiggy-bank/ViewController/NewNoteColorPickerViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NewNoteColorPickerViewController.swift
@@ -1,0 +1,60 @@
+//
+//  NewNoteColorPickerViewController.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/03/10.
+//
+
+import UIKit
+
+class NewNoteColorPickerViewController: UIViewController {
+    
+    // MARK: - @IBOulet
+    
+    // 취소 버튼과 다음 버튼을 담고 있는 내비게이션 바
+    @IBOutlet var navigationBar: UINavigationBar!
+    
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        self.configureNavigationBar()
+    }
+    
+    
+    // MARK: - @IBAction
+    
+    /// 뒤로가기 버튼(<)을 눌렀을 때 호출되는 액션 메서드 : 날짜 피커로 돌아감
+    @IBAction func backButtonDidTap(_ sender: UIBarButtonItem) {
+        self.dismiss(animated: true, completion: nil)
+    }
+    
+    /// 다음 버튼(>)을 눌렀을 때 호출되는 액션 메서드 : 쪽지 작성 뷰를 띄움
+    @IBAction func nextButtonDidTap(_ sender: UIBarButtonItem) {
+        self.performSegue(withIdentifier: SegueIdentifier.presentNewNoteTextView, sender: sender)
+    }
+    
+    
+    // MARK: - Functions
+    
+    /// 내비게이션 바 UI 설정
+    private func configureNavigationBar() {
+        /// 투명 배경
+        self.navigationBar.setBackgroundImage(UIImage(), for: .default)
+        /// 하단 선 제거
+        self.navigationBar.shadowImage = UIImage()
+    }
+    
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/Happiggy-bank/Happiggy-bank/ViewController/NewNoteDatePickerViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NewNoteDatePickerViewController.swift
@@ -1,0 +1,63 @@
+//
+//  NewNoteDatePickerViewController.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/03/10.
+//
+
+import UIKit
+
+class NewNoteDatePickerViewController: UIViewController {
+    
+    // MARK: - @IBOutlet
+    
+    // 취소 버튼과 다음 버튼을 담고 있는 내비게이션 바
+    @IBOutlet var navigationBar: UINavigationBar!
+    
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.configureNavigationBar()
+    }
+
+    
+    // MARK: - @IBAction
+    
+    /// 취소 버튼(x)을 눌렀을 때 호출되는 액션 메서드 : 보틀뷰(홈뷰)로 돌아감
+    @IBAction func cancelButtonDidTap(_ sender: UIBarButtonItem) {
+        self.fadeOut()
+        self.dismiss(animated: false, completion: nil)
+    }
+    
+    
+    /// 다음 버튼(>) 을 눌렀을 때 호출되는 액션 메서드 : 컬러 피커를 띄움
+    @IBAction func nextButtonDidTap(_ sender: UIBarButtonItem) {
+        self.performSegue(
+            withIdentifier: SegueIdentifier.presentNewNoteColorPicker,
+            sender: sender
+        )
+    }
+    
+    
+    // MARK: - Functions
+    
+    /// 내비게이션 바 UI 설정
+    private func configureNavigationBar() {
+        self.navigationBar.setBackgroundImage(UIImage(), for: .default)
+        self.navigationBar.shadowImage = UIImage()
+    }
+    
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/Happiggy-bank/Happiggy-bank/ViewController/NewNotePopupViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NewNotePopupViewController.swift
@@ -315,11 +315,11 @@ final class NewNotePopupViewController: UIViewController {
         }
     }
     
-    /// 팝업이 사라질 때 페이드아웃 효과를 줌
-    private func fadeOut() {
-        self.view.window!.layer.add(CATransition().fadeTransition(), forKey: kCATransition)
-        self.view.isHidden = true
-    }
+//    /// 팝업이 사라질 때 페이드아웃 효과를 줌
+//    private func fadeOut() {
+//        self.view.window!.layer.add(CATransition.fadeTransition(), forKey: kCATransition)
+//        self.view.isHidden = true
+//    }
     
     /// 현재 글자수 라벨을 업데이트
     private func updateLetterCountLabel(count: Int) {

--- a/Happiggy-bank/Happiggy-bank/ViewController/NewNoteTextViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NewNoteTextViewController.swift
@@ -1,0 +1,62 @@
+//
+//  NewNoteTextViewController.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/03/10.
+//
+
+import UIKit
+
+class NewNoteTextViewController: UIViewController {
+    
+    // MARK: - @IBOutlet
+    
+    // 취소 버튼과 다음 버튼을 담고 있는 내비게이션 바
+    @IBOutlet var navigationBar: UINavigationBar!
+    
+    
+    // MARK: - Life cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        self.configureNavigationBar()
+    }
+    
+    
+    // MARK: - @IBAction
+    
+    /// 취소버튼(x)을 눌렀을 때 호출되는 액션 메서드 : 보틀뷰(홈뷰)로 돌아감
+    @IBAction func cancelButtonDidTap(_ sender: UIBarButtonItem) {
+        self.performSegue(withIdentifier: SegueIdentifier.unwindToBotteView, sender: sender)
+        self.fadeOut()
+    }
+    
+    /// 저장버튼(v)을 눌렀을 때 호출되는 액션 메서드
+    @IBAction func saveButtonDidTap(_ sender: UIBarButtonItem) {
+        print("save new note to core data")
+        print("notify note addition/or make core data do it...?")
+        self.performSegue(withIdentifier: SegueIdentifier.unwindToBotteView, sender: sender)
+        self.fadeOut()
+    }
+    
+    
+    // MARK: - Functions
+    
+    /// 내비게이션 바 UI 설정
+    private func configureNavigationBar() {
+        self.navigationBar.setBackgroundImage(UIImage(), for: .default)
+        self.navigationBar.shadowImage = UIImage()
+    }
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}


### PR DESCRIPTION
## 작업 내용
이슈 #26 

### 스토리보드 
- NewNoteDatePickerViewController, NewNoteColorPickerViewController, NewNoteTextViewController
- 새로운 뷰컨트롤러를 present modally + (over)fullScreen 옵션으로 적용해서 사용
  - 내장된 cross dissolve 애니메이션 효과 사용 위함
- navigation bar 추가 해서 취소/이동/저장 버튼 이동 효과만 구현 해둠
  - 투명 배경 + 하단선 제거를 위해 각 뷰컨의 viewDidLoad 에 로직 추가 

<br>

### BottleViewController
- buttonDidTap 분기 실수 수정(이미 모든날 쪽지 작성한 경우 <-> 쪽지 작성 가능한 경우)
- 쪽지 작성 가능한 경우 데이트 피커 뷰를 띄우도록 함
- 쪽지 작성 뷰 컨트롤러에서 돌아올 수 있도록 unwindCallDidArrive(segue:) 메서드 추가

<br>

### UIViewController+FadeOut
- NewNotePopupController 의 메서드였던 fadeOut() 을 화면 전환에 쓰려고 옮겨옴


<br> 

### 그 외
- Constant 파일 최대 줄 길이 넘었다고 SwiftLint 경고 뜨는 거 짱받아서 해당 파일만 줄 수 disable 설정
- Constant 에 SegueIdentifier enum 추가
- 기존의 NewNotePopupController 는 이슈 #26 완료하면 삭제하겠습니다(거기서 소스 뜯어다가 쓰고 있어서...ㅋㅋㅋㅋㅋ)

<br>

## 추후 작업
- 날짜 피커, 컬러 피커, 쪽지 작성 뷰 순차적으로 작업 예정

<br>

여기까지만도 너무 오래걸려서 다 하고 올리면 너무 큰 풀리퀘가 될 거 같기도 하고 넘 늦어질 거 같아서 한 번 끊어서 보냅니다... 