### PR TITLE
[fix] 새로운 저금통 기간 피커에서 저장 버튼 누르면 충돌 발생하는 문제 수정 #32

### DIFF
--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -563,6 +563,7 @@
                     <size key="freeformSize" width="375" height="812"/>
                     <connections>
                         <outlet property="navigationBar" destination="VaU-DG-hJr" id="DcT-tm-v6Y"/>
+                        <segue destination="rAE-WY-Wyc" kind="unwind" identifier="unwindFromNewBottlePopupToBottleView" unwindAction="unwindCallDidArriveWithSegue:" id="voH-uq-YvW"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jnb-AF-gmu" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>


### PR DESCRIPTION
## 작업내용
- 이슈 #32 

<br>

- 새로운 쪽지 컬러 피커에서 unwind segue 추가하면서 저금통 피커의 unwind segue 를 삭제했던 게 원인
  - 스토리보드에서 segue 다시 설정

흑흑 실수로 어제 컬러 피커에서 unwind segue 추가하면서 스토리보드에서 잘못 건드렸나봐요 죄송합니다...바꿔서 빠르게 머지했습니다...!