### PR TITLE
[fix] 쪽지 리스트에서 셀 내부 뷰들의 크기 및 애니메이션 버그 수정 #50

### DIFF
--- a/Happiggy-bank/Happiggy-bank/Storyboard/NoteCell.xib
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/NoteCell.xib
@@ -18,22 +18,22 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="cL4-kp-d58">
-                        <rect key="frame" x="24" y="8" width="279" height="226"/>
+                        <rect key="frame" x="0.0" y="0.0" width="327" height="226"/>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wbq-Tz-IcI">
-                        <rect key="frame" x="143" y="111" width="41.5" height="20.5"/>
+                        <rect key="frame" x="143" y="103" width="41.5" height="20.5"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gz4-u7-xg9">
-                        <rect key="frame" x="40" y="24" width="41.5" height="20.5"/>
+                        <rect key="frame" x="16" y="16" width="41.5" height="20.5"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="97k-pG-TgR">
-                        <rect key="frame" x="40" y="52.5" width="247" height="23"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsLetterSpacingToFitWidth="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="97k-pG-TgR">
+                        <rect key="frame" x="16" y="44.5" width="295" height="23"/>
                         <fontDescription key="fontDescription" type="system" pointSize="19"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
@@ -42,15 +42,15 @@
                 <constraints>
                     <constraint firstItem="wbq-Tz-IcI" firstAttribute="centerX" secondItem="cL4-kp-d58" secondAttribute="centerX" id="GnB-is-11l"/>
                     <constraint firstItem="97k-pG-TgR" firstAttribute="trailing" secondItem="cL4-kp-d58" secondAttribute="trailing" constant="-16" id="Kz8-yY-XdN"/>
-                    <constraint firstAttribute="trailing" secondItem="cL4-kp-d58" secondAttribute="trailing" constant="24" id="P3d-aG-y6K"/>
+                    <constraint firstAttribute="trailing" secondItem="cL4-kp-d58" secondAttribute="trailing" id="P3d-aG-y6K"/>
                     <constraint firstItem="97k-pG-TgR" firstAttribute="leading" secondItem="gz4-u7-xg9" secondAttribute="leading" id="QIA-g9-QDv"/>
-                    <constraint firstAttribute="bottom" secondItem="cL4-kp-d58" secondAttribute="bottom" constant="8" id="R6a-40-KyS"/>
+                    <constraint firstAttribute="bottom" secondItem="cL4-kp-d58" secondAttribute="bottom" constant="16" id="R6a-40-KyS"/>
                     <constraint firstItem="gz4-u7-xg9" firstAttribute="leading" secondItem="cL4-kp-d58" secondAttribute="leading" constant="16" id="b2R-Rb-JSL"/>
-                    <constraint firstItem="cL4-kp-d58" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="bN2-YG-06e"/>
+                    <constraint firstItem="cL4-kp-d58" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="bN2-YG-06e"/>
                     <constraint firstItem="97k-pG-TgR" firstAttribute="top" secondItem="gz4-u7-xg9" secondAttribute="bottom" constant="8" id="dKc-r8-Kve"/>
                     <constraint firstItem="wbq-Tz-IcI" firstAttribute="centerY" secondItem="cL4-kp-d58" secondAttribute="centerY" id="qua-zL-hP1"/>
                     <constraint firstItem="gz4-u7-xg9" firstAttribute="top" secondItem="cL4-kp-d58" secondAttribute="top" constant="16" id="rhV-hr-tOW"/>
-                    <constraint firstItem="cL4-kp-d58" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="24" id="tye-y5-iSc"/>
+                    <constraint firstItem="cL4-kp-d58" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="tye-y5-iSc"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>

--- a/Happiggy-bank/Happiggy-bank/Subview/NoteCell.swift
+++ b/Happiggy-bank/Happiggy-bank/Subview/NoteCell.swift
@@ -30,6 +30,19 @@ final class NoteCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
     }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        self.contentView.frame = self.contentView.frame.inset(
+            by: UIEdgeInsets(
+                top: .zero,
+                left: Metric.horizontalPadding,
+                bottom: .zero,
+                right: Metric.horizontalPadding
+            )
+        )
+    }
 
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -412,14 +412,8 @@ extension NoteListViewController {
     /// NoteListViewController 에서 사용하는 상수값
     enum Metric {
         
-        /// note cell 세로:가로 비율 : 242/327
-        private static let noteImageSizeRatio: CGFloat = 242/327
-        
         /// 좌우 패딩: 24
-        private static let horizontalPadding: CGFloat = 24
-        
-        /// 쪽지 이미지 사이 간격: 16
-        private static let noteImageSpacing: CGFloat = 16
+        static let horizontalPadding: CGFloat = 24
         
         /// 쪽지 이미지 너비
         static let noteImageWidth = UIScreen.main.bounds.width - 2 * horizontalPadding
@@ -427,8 +421,14 @@ extension NoteListViewController {
         /// 쪽지 이미지 높이
         static let noteImageHeight = noteImageWidth * noteImageSizeRatio
         
-        /// note cell 높이 : 쪽지 이미지 높이 + 2 * spacing
+        /// note cell 높이 : 쪽지 이미지 높이 + spacing
         static let cellHeight = noteImageHeight + noteImageSpacing
+
+        /// note cell 세로:가로 비율 : 242/327
+        private static let noteImageSizeRatio: CGFloat = 242/327
+        
+        /// 쪽지 이미지 사이 간격: 16
+        private static let noteImageSpacing: CGFloat = 16
     }
 }
 
@@ -440,8 +440,11 @@ extension NoteCell {
         /// 애니메이션 지속 시간: 0.6
         static let animationDuration: TimeInterval = 0.6
         
-        /// 0.5
+        /// 50%
         static let half: Double = 0.5
+        
+        /// 좌우 패딩: 25
+        static let horizontalPadding = NoteListViewController.Metric.horizontalPadding
     }
 }
 


### PR DESCRIPTION
## 반영사항
- 이슈 #50 

<br>

UI 디자인 반영하면서 좌우 패딩을 변경했는데, 변경 전에는 디바이스에서 잘 작동했고, 변경 후에도 다른 시뮬레이터에서는 잘 작동했는데 아이폰 13미니 디바이스와 시뮬레이터 모두에서 스크롤 하면 이미지 위치가 틀어지면서 애니메이션에도 버그가 발생하는 문제가 있었습니다

은빈님 코드 참고해서 noteImageView leading, trailing anchor 를 contentView 와 같게 하고 layoutSubviews 에서 contentView 의 프레임을 조정하는 방식으로 변경했는데 혹시 이렇게 하면 왜 해결되는 건지 함 봐주실 수 있을까용(원래는 걍 xib 파일에서 noteImageView 의 constraint 들을 contentView 에 패딩값만큼 더하거나 빼서 설정하는 방식이었습니다)