### PR TITLE
[feat] 저금통 리스트 셀에 쪽지 이미지들을 담은 그리드 추가, 셀 라벨 색상 적용 #43 #36

### DIFF
--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		A44E901727D5EB130053AC57 /* Happiggy-bank.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = A44E901527D5EB130053AC57 /* Happiggy-bank.xcdatamodeld */; };
 		A456657C27CC66FD007CF70A /* DefaultButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A817430027C112D00016C921 /* DefaultButton.swift */; };
 		A456657E27CC77A9007CF70A /* Date+Formatted.swift in Sources */ = {isa = PBXBuildFile; fileRef = A456657D27CC77A9007CF70A /* Date+Formatted.swift */; };
+		A459003A27E95D6B003010A0 /* Grid.swift in Sources */ = {isa = PBXBuildFile; fileRef = A459003927E95D6B003010A0 /* Grid.swift */; };
+		A459003C27E9C5C9003010A0 /* CGSize+Area.swift in Sources */ = {isa = PBXBuildFile; fileRef = A459003B27E9C5C9003010A0 /* CGSize+Area.swift */; };
 		A467B5C827DA258700AC702D /* NewNoteDatePickerRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A467B5C727DA258700AC702D /* NewNoteDatePickerRowView.swift */; };
 		A467B5CA27DA289600AC702D /* NewNoteDatePickerRowView.xib in Resources */ = {isa = PBXBuildFile; fileRef = A467B5C927DA289500AC702D /* NewNoteDatePickerRowView.xib */; };
 		A490AC4E27DD945E00B04CE1 /* NoteListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A490AC4D27DD945E00B04CE1 /* NoteListViewController.swift */; };
@@ -77,6 +79,8 @@
 /* Begin PBXFileReference section */
 		A44E901627D5EB130053AC57 /* Happigy-bank.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Happigy-bank.xcdatamodel"; sourceTree = "<group>"; };
 		A456657D27CC77A9007CF70A /* Date+Formatted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Formatted.swift"; sourceTree = "<group>"; };
+		A459003927E95D6B003010A0 /* Grid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Grid.swift; sourceTree = "<group>"; };
+		A459003B27E9C5C9003010A0 /* CGSize+Area.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGSize+Area.swift"; sourceTree = "<group>"; };
 		A467B5C727DA258700AC702D /* NewNoteDatePickerRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNoteDatePickerRowView.swift; sourceTree = "<group>"; };
 		A467B5C927DA289500AC702D /* NewNoteDatePickerRowView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NewNoteDatePickerRowView.xib; sourceTree = "<group>"; };
 		A490AC4D27DD945E00B04CE1 /* NoteListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteListViewController.swift; sourceTree = "<group>"; };
@@ -246,6 +250,7 @@
 				A8BD833E27BE30B400E0DE41 /* Constants.swift */,
 				A819CF9E27DDD97C00DE8E72 /* HapticManager.swift */,
 				D2C48BFE27E9D60A006FC59E /* Gravity.swift */,
+				A459003927E95D6B003010A0 /* Grid.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -293,6 +298,7 @@
 				A4C1AFC527E482E10096CD3E /* CGFloat+Values.swift */,
 				A4C1AFCD27E4F8150096CD3E /* UIView+FadeInOut.swift */,
 				A4C1AFD327E5E6120096CD3E /* UITextView+ParagraphStyle.swift */,
+				A459003B27E9C5C9003010A0 /* CGSize+Area.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -489,6 +495,7 @@
 				D2C48BFF27E9D60A006FC59E /* Gravity.swift in Sources */,
 				A8EB5E8B27C8B087005704F2 /* UIButton+Extension.swift in Sources */,
 				A843331F27DA013800A12A54 /* NewBottleNameFieldViewController.swift in Sources */,
+				A459003C27E9C5C9003010A0 /* CGSize+Area.swift in Sources */,
 				A4C1AFC427E47DC50096CD3E /* String+NSMutableAttributedStringify.swift in Sources */,
 				A4C1AFC027E477180096CD3E /* NSMutableAttributedString+ColorBold.swift in Sources */,
 				A491018F27D735920012DFDD /* Note+CoreDataClass.swift in Sources */,
@@ -500,6 +507,7 @@
 				A44E901727D5EB130053AC57 /* Happiggy-bank.xcdatamodeld in Sources */,
 				A4C1AFD427E5E6120096CD3E /* UITextView+ParagraphStyle.swift in Sources */,
 				A49931A527BFD20E009FF5A8 /* UIImage+AssetImages.swift in Sources */,
+				A459003A27E95D6B003010A0 /* Grid.swift in Sources */,
 				A4C1AFC227E47AD80096CD3E /* String+EmptyString.swift in Sources */,
 				A4C1AFC627E482E10096CD3E /* CGFloat+Values.swift in Sources */,
 				A8BD833F27BE30B400E0DE41 /* Constants.swift in Sources */,

--- a/Happiggy-bank/Happiggy-bank/CoreData/Bottle+CoreDataClass.swift
+++ b/Happiggy-bank/Happiggy-bank/CoreData/Bottle+CoreDataClass.swift
@@ -84,9 +84,12 @@ public class Bottle: NSManagedObject {
         endDate_ ?? Date()
     }
     
-    /// 해당 저금통에 들어있는 쪽지들의 Set
-    var notes: Set<Note> {
-        notes_ as? Set<Note> ?? []
+    /// 해당 저금통에 들어있는 쪽지들의 배열
+    var notes: [Note] {
+        guard let notes = self.notes_ as? Set<Note>
+        else { return [] }
+        
+        return notes.map { $0 }.sorted { $0.date < $1.date }
     }
     
     // TODO: 유저가 앱을 켜놓은 상태에서 기한이 지나면?
@@ -113,7 +116,9 @@ public class Bottle: NSManagedObject {
     /// 시작 날짜부터 끝 날짜까지의 텍스트 라벨
     /// 2022.02.05 ~ 2022.02.05 형식
     var dateLabel: String {
-        self.startDate.customFormatted(type: .dot) + StringLiteral.center + self.endDate.customFormatted(type: .dot)
+        self.startDate.customFormatted(type: .spaceAndDot)
+        + StringLiteral.center
+        + self.endDate.customFormatted(type: .spaceAndDot)
     }
 }
 
@@ -125,19 +130,28 @@ extension Bottle {
     
     /// 테스트용 목 데이터
     static let foo: Bottle = {
-        
-        let startDate = nthDayFromToday(-10)
-        let endDate = nthDayFromToday(10)
+        let count = 365
+        let startDate = nthDayFromToday(-count)
+        let endDate = nthDayFromToday(5)
         
         let bottle = Bottle(title: "행복냠냠이", startDate: startDate, endDate: endDate)
         
+        for index in -count..<0 {
+            Note.create(
+                date: nthDayFromToday(-index),
+//                color: [NoteColor.pink, NoteColor.purple].randomElement()!,
+                color: NoteColor.allCases.randomElement()!,
+//                color: .yellow,
+                content: "일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십",
+                bottle: bottle)
+        }
         // swiftlint:disable line_length
-        Note.create(date: startDate, color: NoteColor.green, content: "시작!", bottle: bottle)
-        Note.create(date: nthDayFromToday(-9), color: NoteColor.pink, content: "일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십", bottle: bottle)
-        Note.create(date: nthDayFromToday(-3), color: NoteColor.white, content: "100자 좀 적은가? 근데 괜찮은 것 같기도 하고...늘리기는 또 귀찮은데...", bottle: bottle)
-        Note.create(date: nthDayFromToday(-8), color: NoteColor.purple, content: "왜냐면 한줄만 쓰는 날도 백퍼 있을 것이기 때문", bottle: bottle)
-        Note.create(date: nthDayFromToday(-1), color: NoteColor.yellow, content: "졸리다 졸려 졸려", bottle: bottle)
-        Note.create(date: nthDayFromToday(0), color: NoteColor.yellow, content: "누가 뚝딱 만들어주면 좋겠다 한 3줄 정도까지 채우고 싶은데 아무거나 써보기 이모지도 써보기 시험 시험 테스트 ☀️", bottle: bottle)
+//        Note.create(date: startDate, color: NoteColor.green, content: "시작!", bottle: bottle)
+//        Note.create(date: nthDayFromToday(-9), color: NoteColor.pink, content: "일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십", bottle: bottle)
+//        Note.create(date: nthDayFromToday(-3), color: NoteColor.white, content: "100자 좀 적은가? 근데 괜찮은 것 같기도 하고...늘리기는 또 귀찮은데...", bottle: bottle)
+//        Note.create(date: nthDayFromToday(-8), color: NoteColor.purple, content: "왜냐면 한줄만 쓰는 날도 백퍼 있을 것이기 때문", bottle: bottle)
+//        Note.create(date: nthDayFromToday(-1), color: NoteColor.yellow, content: "졸리다 졸려 졸려", bottle: bottle)
+//        Note.create(date: nthDayFromToday(0), color: NoteColor.yellow, content: "누가 뚝딱 만들어주면 좋겠다 한 3줄 정도까지 채우고 싶은데 아무거나 써보기 이모지도 써보기 시험 시험 테스트 ☀️", bottle: bottle)
         
         // swiftlint:enable line_length
         return bottle

--- a/Happiggy-bank/Happiggy-bank/Extensions/CGSize+Area.swift
+++ b/Happiggy-bank/Happiggy-bank/Extensions/CGSize+Area.swift
@@ -1,0 +1,16 @@
+//
+//  CGSize+Area.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/03/22.
+//
+
+import UIKit
+
+extension CGSize {
+    
+    /// 넓이
+    var area: CGFloat {
+        self.width * self.height
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/Storyboard/BottleCell.xib
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/BottleCell.xib
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -22,29 +23,36 @@
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bottleListBottleBack" translatesAutoresizingMaskIntoConstraints="NO" id="h6q-bQ-oRA">
                         <rect key="frame" x="0.0" y="0.0" width="327" height="262"/>
                     </imageView>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ubt-Nc-Vrq">
+                        <rect key="frame" x="122" y="83" width="85" height="85"/>
+                    </view>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bottleListBottleFront" translatesAutoresizingMaskIntoConstraints="NO" id="WBF-j1-MPQ">
                         <rect key="frame" x="0.0" y="0.0" width="327" height="262"/>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="date label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bf2-ek-5mu">
-                        <rect key="frame" x="126" y="221" width="75" height="21"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <nil key="textColor"/>
+                        <rect key="frame" x="128" y="222.5" width="71" height="19.5"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                        <color key="textColor" name="bottleListDateLabelColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="title label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vKx-P5-VKL">
-                        <rect key="frame" x="129" y="192" width="69" height="21"/>
+                        <rect key="frame" x="129" y="193.5" width="69" height="21"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <nil key="textColor"/>
+                        <color key="textColor" name="primaryLabelColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>
                 <constraints>
+                    <constraint firstItem="Ubt-Nc-Vrq" firstAttribute="height" secondItem="h6q-bQ-oRA" secondAttribute="height" multiplier="0.324427" id="0rz-Ij-EDr"/>
                     <constraint firstItem="vKx-P5-VKL" firstAttribute="centerX" secondItem="DOZ-Da-Rub" secondAttribute="centerX" id="9Ht-gb-3qd"/>
                     <constraint firstAttribute="trailing" secondItem="h6q-bQ-oRA" secondAttribute="trailing" id="AiC-C7-BAR"/>
                     <constraint firstAttribute="trailing" secondItem="WBF-j1-MPQ" secondAttribute="trailing" id="Ewx-de-AJP"/>
+                    <constraint firstItem="Ubt-Nc-Vrq" firstAttribute="top" secondItem="DOZ-Da-Rub" secondAttribute="top" constant="83" id="Iy3-nE-a2t"/>
                     <constraint firstItem="6tB-vT-ges" firstAttribute="leading" secondItem="DOZ-Da-Rub" secondAttribute="leading" id="PZd-at-V3w"/>
+                    <constraint firstItem="Ubt-Nc-Vrq" firstAttribute="width" secondItem="h6q-bQ-oRA" secondAttribute="width" multiplier="0.259939" id="Q7M-D1-HnN"/>
                     <constraint firstItem="h6q-bQ-oRA" firstAttribute="leading" secondItem="DOZ-Da-Rub" secondAttribute="leading" id="SO6-cP-qFe"/>
                     <constraint firstAttribute="bottom" secondItem="bf2-ek-5mu" secondAttribute="bottom" constant="20" id="UeF-MR-bFk"/>
+                    <constraint firstItem="Ubt-Nc-Vrq" firstAttribute="centerX" secondItem="h6q-bQ-oRA" secondAttribute="centerX" constant="1" id="VGk-iD-ODb"/>
                     <constraint firstAttribute="bottom" secondItem="6tB-vT-ges" secondAttribute="bottom" id="W4N-XT-RPQ"/>
                     <constraint firstItem="6tB-vT-ges" firstAttribute="top" secondItem="DOZ-Da-Rub" secondAttribute="top" id="Yf2-Xh-T0I"/>
                     <constraint firstItem="WBF-j1-MPQ" firstAttribute="leading" secondItem="DOZ-Da-Rub" secondAttribute="leading" id="ZJ6-aZ-R3e"/>
@@ -60,6 +68,8 @@
             <connections>
                 <outlet property="bottleDateLabel" destination="bf2-ek-5mu" id="XWs-rY-i5N"/>
                 <outlet property="bottleTitleLabel" destination="vKx-P5-VKL" id="d1y-H6-iak"/>
+                <outlet property="gridContainerTopConstraint" destination="Iy3-nE-a2t" id="JIb-O3-Itp"/>
+                <outlet property="gridContainerView" destination="Ubt-Nc-Vrq" id="aqr-r8-2mA"/>
             </connections>
             <point key="canvasLocation" x="-250.00000000000003" y="199.55357142857142"/>
         </tableViewCell>
@@ -68,5 +78,11 @@
         <image name="bottleCellBackgroundLight" width="327" height="262"/>
         <image name="bottleListBottleBack" width="327" height="262"/>
         <image name="bottleListBottleFront" width="327" height="262"/>
+        <namedColor name="bottleListDateLabelColor">
+            <color red="0.45882352941176469" green="0.70196078431372544" blue="0.74509803921568629" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="primaryLabelColor">
+            <color red="0.0" green="0.36078431372549019" blue="0.61960784313725492" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
     </resources>
 </document>

--- a/Happiggy-bank/Happiggy-bank/Subview/BottleCell.swift
+++ b/Happiggy-bank/Happiggy-bank/Subview/BottleCell.swift
@@ -9,8 +9,6 @@ import UIKit
 
 import Then
 
-// TODO: bottleContentView 필요 -> 쪽지 채워진 모양
-
 /// 저금통 리스트의 셀
 final class BottleCell: UITableViewCell {
     
@@ -21,7 +19,20 @@ final class BottleCell: UITableViewCell {
 
     /// 저금통 기간 라벨
     @IBOutlet weak var bottleDateLabel: UILabel!
-
+    
+    /// 그리드 프레임 역할을 할 컨테이너 뷰
+    @IBOutlet weak var gridContainerView: UIView!
+    
+    /// 그리드 컨테이너 뷰 top constraint
+    @IBOutlet weak var gridContainerTopConstraint: NSLayoutConstraint!
+    
+    /// 쪽지를 채울 그리드 
+    private var grid = Grid()
+    
+    // TODO: 불필요할수도?
+    /// 그리드 각 셀에 들어있는 노트 이미지 뷰
+    private var noteViews = [UIView]()
+    
     
     // MARK: - override func
     
@@ -32,11 +43,13 @@ final class BottleCell: UITableViewCell {
     override func layoutSubviews() {
         super.layoutSubviews()
         
+        self.gridContainerTopConstraint.constant = Metric.gridTopConstraintConstant
+
         contentView.frame = contentView.frame.inset(
             by: UIEdgeInsets(
                 top: Metric.cellSpacing,
                 left: Metric.horizontalPadding,
-                bottom: 0,
+                bottom: .zero,
                 right: Metric.horizontalPadding
             )
         )
@@ -44,6 +57,43 @@ final class BottleCell: UITableViewCell {
     
     
     // MARK: - cell settings
+    
+    /// 유리병 내부 영역을 직사각형의 그리드로 나누고 쪽지 이미지로 채움
+    func fillGrid(withNotes notes: [Note]) {
+        self.layoutIfNeeded()
+
+        self.grid = Grid(frame: self.gridContainerView.bounds, cellCount: notes.count)
+        
+        for index in 0..<notes.count {
+            let note = notes[index]
+            
+            let noteContainerView = UIView(frame: self.grid[index] ?? .zero).then {
+                $0.layer.zPosition = Metric.randomZpostion
+            }
+            
+            let imageView = UIImageView(image: .note(color: note.color)).then {
+                $0.frame.size = noteContainerView.bounds.size
+                
+                /// 크기 조정
+                let randomScale = Metric.randomScale
+                $0.transform = $0.transform.scaledBy(x: randomScale, y: randomScale)
+                
+                /// 회전
+                $0.transform = $0.transform.rotated(by: Metric.randomDegree)
+            }
+            
+            noteContainerView.addSubview(imageView)
+            self.gridContainerView.addSubview(noteContainerView)
+            self.noteViews.append(noteContainerView)
+        }
+    }
+    
+    /// 셀 재사용을 위해 그리드와 쪽지 뷰들 초기화
+    func resetAttributes() {
+        self.grid = Grid()
+        self.noteViews.forEach { $0.removeFromSuperview() }
+        self.noteViews = []
+    }
     
     /// 셀 라벨 폰트사이즈, 색상 설정
     private func configureLabels() {

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -110,7 +110,7 @@ extension BottleListViewController {
     enum Metric {
         
         /// 테이블뷰 행 높이
-        static let cellHeight: CGFloat = BottleCell.Metric.cellHeight + BottleCell.Metric.horizontalPadding
+        static let cellHeight: CGFloat = BottleCell.Metric.cellHeight + BottleCell.Metric.cellSpacing
     }
     
     /// BottleListViewController에서 설정하는 Color 상수값
@@ -190,6 +190,36 @@ extension BottleCell {
         
         /// corner radius
         static let cornerRadius: CGFloat = 15
+        
+        /// 그리드 top constraint 를 비율에 따라 조정한 값
+        static let gridTopConstraintConstant = cellHeight * gridTopConstraintCellHeightRatio
+        
+        /// 쪽지 이미지들의 z index
+        static var randomZpostion: CGFloat {
+            [3, 4, 5, 6, 7, 8].randomElement() ?? 3
+        }
+        
+        /// 쪽지 이미지 scale
+        static var randomScale: CGFloat {
+            [1, 1.1, 1.2, 1.3, 1.4, 1.5].randomElement() ?? .one
+        }
+        
+        /// 쪽지 이미지 회전 각도
+        static var randomDegree: CGFloat {
+            2 * .pi / (degreeDividers.randomElement() ?? .one)
+        }
+        
+        /// 쪽지 이미지들의 회전 각도를 구하기 위한 값들
+        private static let degreeDividers: [CGFloat] = {
+            var degree = [CGFloat]()
+            for number in 1...36 {
+                degree.append(CGFloat(number))
+            }
+            return degree
+        }()
+        
+        /// 그리드 top constraint 와 셀 높이 간 비율
+        private static let gridTopConstraintCellHeightRatio: CGFloat = 83 / 262
     }
     
     /// Bottle Cell에서 설정하는 글자 크기

--- a/Happiggy-bank/Happiggy-bank/Utils/Grid.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Grid.swift
@@ -1,0 +1,166 @@
+//
+//  Grid.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/03/22.
+//
+
+import UIKit
+
+/// 직사각형 영역의 내부를 n개의 셀로 이루어진 그리드로 나눔
+struct Grid {
+    
+    // MARK: - Properties
+    
+    /// 그리드를 만들 영역의 프레임
+    /// 변경 시 셀 크기가 자동으로 조정됨
+    var frame: CGRect { didSet {
+        self.calculate()
+    }}
+
+    /// 너비/높이 비율
+    /// 변경 시 셀 크기가 자동으로 조정됨
+    var aspectRatio: CGFloat { didSet { self.calculate()} }
+    
+    /// 그리드 내부 셀 개수
+    /// 변경 시 셀 크기가 자동으로 조정됨
+    var cellCount: Int { didSet { self.calculate() }}
+    
+    /// 셀 크기
+    var cellSize: CGSize { self.cellFrames.first?.size ?? .zero }
+    
+    /// 조건을 만족하는 최대 크기의 셀로 영역을 채울때 행, 열 수
+    private(set) var dimensions: (rowCount: Int, columnCount: Int) = (.zero, .zero)
+
+    /// 셀들의 프레임을 좌하단부터 순서대로 담고 있는 배열
+    /// subscript 로 각 영역에 접근해서 UIView 의 프레임으로 사용하는 등 목적에 맞게 사용
+    private var cellFrames = [CGRect]()
+    
+    
+    // MARK: - Subscript
+    
+    /// 해당 인덱스의 셀 프레임이 있는 경우 프레임 반환
+    subscript(index: Int) -> CGRect? {
+        index < self.cellFrames.count ? self.cellFrames[index] : nil
+    }
+    
+    
+    // MARK: - Init
+    
+    /// 프레임, 셀 개수, 셀 너비/높이 비율을 설정하면 조건을 만족하는 가장 큰 셀 크기로 그리드를 구성
+    init(frame: CGRect = .zero, cellCount: Int = .zero, aspectRatio: CGFloat = .one) {
+        self.frame = frame
+        self.cellCount = cellCount
+        self.aspectRatio = aspectRatio
+        self.calculate()
+    }
+    
+    
+    // MARK: - Functions
+    
+    /// 조건에 따라 그리드를 구성했을 때의 행, 열 개수를 계산하는 메서드
+    private mutating func calculate() {
+        let cellSize = largestCellSizeThatFits()
+        
+        guard cellSize.area > .zero
+        else {
+            self.dimensions = (.zero, .zero)
+            self.updateCellFrames(to: cellSize)
+            return
+        }
+        
+        self.dimensions.columnCount = Int(self.frame.width / cellSize.width)
+        /// 마지막 행은 꽉 차있지 않을 수도 있으므로 나머지로 계산되지 않도록 열 개수 - 1 만큼 추가
+        self.dimensions.rowCount = (self.cellCount + self.dimensions.columnCount - 1) / self.dimensions.columnCount
+        self.updateCellFrames(to: cellSize)
+        
+    }
+    
+    /// 계산한 셀 크기에 맞게 프레임 배열 업데이트
+    private mutating func updateCellFrames(to cellSize: CGSize) {
+
+        self.cellFrames.removeAll()
+        
+        /// 그리드의 실제 크기
+        let boundingSize = CGSize(
+            width: CGFloat(self.dimensions.columnCount) * cellSize.width,
+            height: CGFloat(self.dimensions.rowCount) * cellSize.height
+        )
+        
+        let offset = (
+            dx: (self.frame.width - boundingSize.width) / 2,
+            dy: (self.frame.height - boundingSize.height) / 2
+        )
+        
+        /// 셀들이 실제로 그리드 내부 영역을 딱 맞게 채우지는 못하는 경우 가운데 정렬을 위해서 오프셋을 계산해 시작점을 옮겨줌
+        var origin = self.frame.origin
+        origin.x += offset.dx
+        origin.y += (self.frame.maxY - cellSize.height)
+
+        guard self.cellCount > .zero
+        else { return }
+        
+        /// 맨 아래 행부터 좌->우 방향으로 cellFrame 배열 업데이트
+        for _ in .zero..<self.cellCount {
+            self.cellFrames.append(CGRect(origin: origin, size: cellSize))
+            
+            /// 다음 열로 위치 이동
+            origin.x += cellSize.width
+            
+            /// 이번 행에 더 이상 셀을 넣을 수 없는 경우 한 행 위로 위치를 옮김
+//            if round(origin.x) > round(frame.maxX - cellSize.width) {
+                if origin.x > frame.maxX - cellSize.width {
+//            if origin.x >= boundingSize.width {
+                origin.x = self.frame.origin.x + offset.dx
+                origin.y -= cellSize.height
+            }
+        }
+    }
+    
+    /// 주어진 조건을 만족하는 가장 큰 셀 크기를 구하는 메서드
+    private func largestCellSizeThatFits() -> CGSize {
+        guard self.cellCount > .zero && self.aspectRatio > .zero
+        else { return .zero }
+        
+        var largestSoFar = CGSize.zero
+        
+        for count in 1...cellCount {
+            largestSoFar = self.cellSizeAssuming(rowCount: count, largestSoFar: largestSoFar)
+            largestSoFar = self.cellSizeAssuming(columnCount: count, largestSoFar: largestSoFar)
+        }
+        
+        return largestSoFar
+    }
+    
+    /// 행 혹은 열의 개수가 주어졌을 때 주어진 비율과 프레임을 만족하는 셀 사이즈를 구해서 현재 셀 사이즈와 차지하는 영역을 비교한 다음,
+    /// 현재 셀 사이즈보다 크고, 셀 개수 조건을 충족하는 경우 새로운 값을, 아닐 경우 현재 셀 사이즈를 리턴
+    private func cellSizeAssuming(
+        rowCount: Int? = nil,
+        columnCount: Int? = nil,
+        largestSoFar: CGSize = .zero
+    ) -> CGSize {
+        var size = CGSize.zero
+        
+        /// 열 개수가 주어진 경우
+        if let columnCount = columnCount {
+            size.width = self.frame.width / CGFloat(columnCount)
+            size.height = size.width / self.aspectRatio
+        }
+        /// 행 개수가 주어진 경우
+        if let rowCount = rowCount {
+            size.height = self.frame.height / CGFloat(rowCount)
+            size.width = size.height * self.aspectRatio
+        }
+        
+        /// 현재 셀 사이즈보다 차지하는 영역이 작은 경우 최대가 아니므로 현재 셀 사이즈 리턴
+        guard size.area > largestSoFar.area
+        else { return largestSoFar }
+        
+        let rowCount = Int(frame.size.height / size.height)
+        let columnCount = Int(frame.size.width / size.width)
+        
+        
+        /// 현재 셀 사이즈보다 크더라도 셀 개수를 만족시키지 못할 수 있으므로 확인 후 리턴
+        return rowCount * columnCount >= self.cellCount ? size : largestSoFar
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/ViewController/BottleListViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/BottleListViewController.swift
@@ -47,9 +47,7 @@ final class BottleListViewController: UIViewController {
             else { return }
             
             let viewModel = NoteListViewModel()
-            let notes = Bottle.foo.notes
-            viewModel.notes = notes.map { $0 }
-            viewModel.notes.sort { $0.date < $1.date }
+            viewModel.notes = Bottle.foo.notes
             
             noteListViewController.viewModel = viewModel
         }
@@ -112,6 +110,8 @@ extension BottleListViewController: UITableViewDataSource {
         resetReusableCellAttribute(cell)
         cell.bottleTitleLabel.text = bottle.title
         cell.bottleDateLabel.text = bottle.dateLabel
+        cell.bottleDateLabel.textColor = .bottleListDateLabel
+        cell.fillGrid(withNotes: bottle.notes)
         
         return cell
     }
@@ -126,8 +126,9 @@ extension BottleListViewController: UITableViewDataSource {
     
     /// 리유저블 셀의 속성 초기화하는 함수
     private func resetReusableCellAttribute(_ cell: BottleCell) {
-        cell.bottleTitleLabel.text = ""
-        cell.bottleDateLabel.text = ""
+        cell.bottleTitleLabel.text = .empty
+        cell.bottleDateLabel.text = .empty
+        cell.resetAttributes()
     }
 }
 

--- a/Happiggy-bank/Happiggy-bank/ViewModel/BottleListViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/BottleListViewModel.swift
@@ -28,7 +28,7 @@ final class BottleListViewModel {
     private func executeFetchRequest() {
         guard let list = try? Bottle.fetchRequest(isOpen: true).execute()
         else {
-            self.bottleList = [Bottle.foo]
+            self.bottleList = Array(repeating: Bottle.foo, count: 300)
 //            self.bottleList = []
             return
         }


### PR DESCRIPTION
## 반영 내용
- 이슈 #43
- 이슈 #36 

<br>

### BottleCell 
- 쪽지 이미지들을 작성 순서대로 유리병 안에 나타내기 위해 그리드 추가
  - UIDynamics 쓰면 CPU 폭발해서 차선책 
- 그리드를 사용해서 유리병 내부 영역을 n개의 CGRect 로 나눈 다음, 이를 좌표로 사용해 해당 위치에 subview 를 추가하는 방식
  - gridContainer 가 실체가 있는 UIView 고, grid 는 내부의 투명 뼈대같은...그런...
  - 쪽지 이미지들은 grid 가 아니라 gridContainer 에 추가됨
  - **문제...스크롤 진짜 빠르게 하면 CPU 90%까지 치솟음 흑흑**
- bottle cell height 수정 (vertical spacing 대신 horizontal padding 이 적용되고 있었음)
- 라벨에 디자인 색상 적용, 날짜 라벨 2022.03.01 -> 2022 03.01 형태(연도와 달 사이 점 제거)로 변경 
- 셀 재사용 시 grid, noteView 를 매번 리셋해줘야 해서 관련 함수도 추가

<br>


## 추후 작업
- 그리드 좀 더 섬세하게 분할 (쌓인 모습 예쁘게...)
- 기간 별 사이즈 재확인 필요