### PR TITLE
[feat] 홈 화면 저금통 뷰 그리드 추가 #65

### DIFF
--- a/Happiggy-bank/Happiggy-bank/CoreData/Bottle+CoreDataClass.swift
+++ b/Happiggy-bank/Happiggy-bank/CoreData/Bottle+CoreDataClass.swift
@@ -130,7 +130,7 @@ extension Bottle {
     
     /// 테스트용 목 데이터
     static let foo: Bottle = {
-        let count = 365
+        let count = 300
         let startDate = nthDayFromToday(-count)
         let endDate = nthDayFromToday(5)
         

--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="dSD-O6-Yej">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="dSD-O6-Yej">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
@@ -23,26 +23,26 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                             </imageView>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="homeBottleBack" translatesAutoresizingMaskIntoConstraints="NO" id="oqE-FC-3Q8">
-                                <rect key="frame" x="0.0" y="249.66666666666666" width="375" height="439.33333333333337"/>
+                                <rect key="frame" x="0.0" y="249" width="375" height="440"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" secondItem="oqE-FC-3Q8" secondAttribute="height" multiplier="414:485" id="fo3-oe-RDc"/>
-                                </constraints>
-                            </imageView>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="homeBottleFront" translatesAutoresizingMaskIntoConstraints="NO" id="0dD-IT-dfb">
-                                <rect key="frame" x="0.0" y="249.66666666666666" width="375" height="439.33333333333337"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="0dD-IT-dfb" secondAttribute="height" multiplier="414:485" id="gcC-qP-AxE"/>
+                                    <constraint firstAttribute="width" secondItem="oqE-FC-3Q8" secondAttribute="height" multiplier="375:440" id="fo3-oe-RDc"/>
                                 </constraints>
                             </imageView>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dmA-fx-uIw">
-                                <rect key="frame" x="0.0" y="249.66666666666666" width="375" height="439.33333333333337"/>
+                                <rect key="frame" x="0.0" y="249" width="375" height="440"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" secondItem="dmA-fx-uIw" secondAttribute="height" multiplier="414:485" id="W8J-jy-WPj"/>
+                                    <constraint firstAttribute="width" secondItem="dmA-fx-uIw" secondAttribute="height" multiplier="375:440" id="W8J-jy-WPj"/>
                                 </constraints>
                                 <connections>
                                     <segue destination="FVx-vN-7Xe" kind="embed" identifier="showBottleView" id="rLd-zf-USa"/>
                                 </connections>
                             </containerView>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="homeBottleFront" translatesAutoresizingMaskIntoConstraints="NO" id="0dD-IT-dfb">
+                                <rect key="frame" x="0.0" y="249" width="375" height="440"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="0dD-IT-dfb" secondAttribute="height" multiplier="375:440" id="gcC-qP-AxE"/>
+                                </constraints>
+                            </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Bmu-YM-ARP">
                                 <rect key="frame" x="24" y="100.99999999999999" width="327" height="54.333333333333329"/>
                                 <constraints>
@@ -586,11 +586,11 @@
             <objects>
                 <viewController modalTransitionStyle="crossDissolve" modalPresentationStyle="fullScreen" id="FVx-vN-7Xe" customClass="BottleViewController" customModule="Happiggy_bank" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="jBg-oD-Piv">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="439.33333333333331"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="440"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OAt-vo-L69">
-                                <rect key="frame" x="80" y="165" width="215" height="230.33333333333337"/>
+                                <rect key="frame" x="80" y="165" width="215" height="231"/>
                                 <gestureRecognizers/>
                                 <connections>
                                     <outletCollection property="gestureRecognizers" destination="gEH-ha-I0H" appends="YES" id="I7T-Ve-Zwh"/>
@@ -600,14 +600,15 @@
                         <viewLayoutGuide key="safeArea" id="hOc-mc-UUR"/>
                         <gestureRecognizers/>
                         <constraints>
-                            <constraint firstItem="OAt-vo-L69" firstAttribute="leading" secondItem="hOc-mc-UUR" secondAttribute="leading" constant="80" id="1rR-fu-khc"/>
-                            <constraint firstItem="OAt-vo-L69" firstAttribute="top" secondItem="jBg-oD-Piv" secondAttribute="top" constant="165" id="9UY-ag-ktw"/>
-                            <constraint firstItem="OAt-vo-L69" firstAttribute="trailing" secondItem="hOc-mc-UUR" secondAttribute="trailing" constant="-80" id="MIL-hm-f47"/>
+                            <constraint firstItem="OAt-vo-L69" firstAttribute="centerX" secondItem="hOc-mc-UUR" secondAttribute="centerX" id="lHD-MC-mZ6"/>
+                            <constraint firstItem="OAt-vo-L69" firstAttribute="height" secondItem="jBg-oD-Piv" secondAttribute="height" multiplier="0.525" id="rHf-uW-8wO"/>
                             <constraint firstItem="hOc-mc-UUR" firstAttribute="bottom" secondItem="OAt-vo-L69" secondAttribute="bottom" constant="44" id="rUo-wu-z3X"/>
+                            <constraint firstItem="OAt-vo-L69" firstAttribute="width" secondItem="jBg-oD-Piv" secondAttribute="width" multiplier="0.573333" id="saU-qG-RkR"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="bottleNoteView" destination="OAt-vo-L69" id="Xcn-Ec-cu5"/>
+                        <outlet property="bottleNoteViewBottomConstraint" destination="rUo-wu-z3X" id="oDP-fr-ikO"/>
                         <segue destination="moi-e1-3hQ" kind="presentation" identifier="presentNewNoteDatePicker" id="71M-g6-wMS"/>
                         <segue destination="abG-42-vcb" kind="presentation" identifier="presentNewBottleNameField" id="Qcc-qq-Xqy"/>
                     </connections>

--- a/Happiggy-bank/Happiggy-bank/Subview/BottleCell.swift
+++ b/Happiggy-bank/Happiggy-bank/Subview/BottleCell.swift
@@ -59,10 +59,10 @@ final class BottleCell: UITableViewCell {
     // MARK: - cell settings
     
     /// 유리병 내부 영역을 직사각형의 그리드로 나누고 쪽지 이미지로 채움
-    func fillGrid(withNotes notes: [Note]) {
+    func fillGrid(withNotes notes: [Note], duration: Int) {
         self.layoutIfNeeded()
-
-        self.grid = Grid(frame: self.gridContainerView.bounds, cellCount: notes.count)
+        
+        self.grid = Grid(frame: self.gridContainerView.bounds, cellCount: duration)
         
         for index in 0..<notes.count {
             let note = notes[index]

--- a/Happiggy-bank/Happiggy-bank/Subview/NoteView.swift
+++ b/Happiggy-bank/Happiggy-bank/Subview/NoteView.swift
@@ -42,7 +42,6 @@ final class NoteView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
         self.addSubview(self.imageView)
-        configureConstraints()
 
         layer.addSublayer(shapeLayer)
         let center = CGPoint(x: bounds.midX, y: bounds.midY)
@@ -67,15 +66,5 @@ final class NoteView: UIView {
             endAngle: .pi * 2,
             clockwise: true
         )
-    }
-    
-    /// Constratins 설정
-    private func configureConstraints() {
-        NSLayoutConstraint.activate([
-            self.imageView.topAnchor.constraint(equalTo: self.topAnchor),
-            self.imageView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
-            self.imageView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            self.imageView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
-        ])
     }
 }

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -56,6 +56,30 @@ extension BottleViewController {
         
         /// Gravity에 추가될 수평 패딩
         static let boundaryPadding: CGFloat = 10
+        
+        /// 쪽지 이미지들의 z index
+        static var randomZpostion: CGFloat {
+            [3, 4, 5, 6, 7, 8].randomElement() ?? 3
+        }
+        
+        /// 쪽지 이미지 scale
+        static var randomScale: CGFloat {
+            [1, 1.1, 1.2, 1.3, 1.4, 1.5].randomElement() ?? .one
+        }
+        
+        /// 쪽지 이미지 회전 각도
+        static var randomDegree: CGFloat {
+            2 * .pi / (degreeDividers.randomElement() ?? .one)
+        }
+        
+        /// 쪽지 이미지들의 회전 각도를 구하기 위한 값들
+        private static let degreeDividers: [CGFloat] = {
+            var degree = [CGFloat]()
+            for number in 1...36 {
+                degree.append(CGFloat(number))
+            }
+            return degree
+        }()
     }
 }
 

--- a/Happiggy-bank/Happiggy-bank/Utils/Grid.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Grid.swift
@@ -78,7 +78,7 @@ struct Grid {
     
     /// 계산한 셀 크기에 맞게 프레임 배열 업데이트
     private mutating func updateCellFrames(to cellSize: CGSize) {
-
+    
         self.cellFrames.removeAll()
         
         /// 그리드의 실제 크기
@@ -108,9 +108,7 @@ struct Grid {
             origin.x += cellSize.width
             
             /// 이번 행에 더 이상 셀을 넣을 수 없는 경우 한 행 위로 위치를 옮김
-//            if round(origin.x) > round(frame.maxX - cellSize.width) {
-                if origin.x > frame.maxX - cellSize.width {
-//            if origin.x >= boundingSize.width {
+            if round(origin.x) > round(frame.maxX - cellSize.width) {
                 origin.x = self.frame.origin.x + offset.dx
                 origin.y -= cellSize.height
             }

--- a/Happiggy-bank/Happiggy-bank/ViewController/BottleListViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/BottleListViewController.swift
@@ -111,7 +111,7 @@ extension BottleListViewController: UITableViewDataSource {
         cell.bottleTitleLabel.text = bottle.title
         cell.bottleDateLabel.text = bottle.dateLabel
         cell.bottleDateLabel.textColor = .bottleListDateLabel
-        cell.fillGrid(withNotes: bottle.notes)
+        cell.fillGrid(withNotes: bottle.notes, duration: bottle.duration)
         
         return cell
     }

--- a/Happiggy-bank/Happiggy-bank/ViewModel/BottleViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/BottleViewModel.swift
@@ -14,4 +14,14 @@ final class BottleViewModel {
     // MARK: - Properties
     /// 홈 뷰에서 나타낼 저금통
     var bottle: Bottle?
+    
+    /// 새로 추가한 쪽지
+    var newlyAddedNote: Note? {
+        bottle?.notes.last
+    }
+    
+    /// 새로 추가한 쪽지의 인덱스
+    var newlyAddedNoteIndex: Int? {
+        bottle == nil ? nil : bottle!.notes.count - 1
+    }
 }


### PR DESCRIPTION
## 반영 내용
- 이슈 #65 

<br>

### bottleViewController 
- 그리드 추가, 각 쪽지 위치를 지정해서 위에서 떨어지는 게 아니라 해당 위치에 쪽지가 떨어지도록 함 
 - 그리드로 위치 잡아준 다음에 중력 효과  
 - 잔떨림 현상 많이 줄어들은 것 확인!
 - bottleNoteView 쪽으로 코드를 아예 빼고 싶었는데 무한의 세그폴트가 나서...나중에 리팩토링 해보겠습니다.. 
 
<br>

### 스토리보드 
- 제가 첨에 화면이 원하는대로 안나와서(지금 보니까 아래 수정했다는 그리드 조건 때문이었던 것 같음...) 전체적으로 이번 파트 관련해서constraint 를 좀 손 댔는데 혹시 보시고 이건 건드리면 안됐다 하는 거 있으시면 제가 바로 원상복귀 해두겠습니당

<br>

### Grid
- 가운데 정렬을 위해 grid 영역 분할 조건 변경

<br>

## 추후 작업
- 유저가 새 쪽지를 추가했을 때 홈뷰로부터 알림 받아야 함
 - 해당 용도로 contextDidChange 메서드를 구현해놨고, 그리드에 뷰 추가 해놨는데 나중에 떨어지는 위치 수정해야 될것 같고 제가 더 이상 머리가 돌아가지 않아서 새 쪽지를 dynamic item 으로 추가하는 건 못했습니다... 

<br>

**은빈님이 설정해주신 베지에 패스랑 중력 영역이 고통받던 제게 매우 큰 힘이 되었습니다 다시 한번 감사의 말씀....**