### PR TITLE
[feat] 쪽지리스트 전체 개봉 버튼, 쪽지 개수 라벨 구현, 쪽지 내용 라벨 행간 및 자간 조정 #54 #55 #58 #35

### DIFF
--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -14,6 +14,9 @@
 		A459003C27E9C5C9003010A0 /* CGSize+Area.swift in Sources */ = {isa = PBXBuildFile; fileRef = A459003B27E9C5C9003010A0 /* CGSize+Area.swift */; };
 		A467B5C827DA258700AC702D /* NewNoteDatePickerRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A467B5C727DA258700AC702D /* NewNoteDatePickerRowView.swift */; };
 		A467B5CA27DA289600AC702D /* NewNoteDatePickerRowView.xib in Resources */ = {isa = PBXBuildFile; fileRef = A467B5C927DA289500AC702D /* NewNoteDatePickerRowView.xib */; };
+		A48E183A27E71D9300B44477 /* UILabel+ParagraphStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A48E183927E71D9300B44477 /* UILabel+ParagraphStyle.swift */; };
+		A48E183C27E7379100B44477 /* CapsuleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A48E183B27E7379100B44477 /* CapsuleButton.swift */; };
+		A48E183E27E737B600B44477 /* CapsuleButton.xib in Resources */ = {isa = PBXBuildFile; fileRef = A48E183D27E737B600B44477 /* CapsuleButton.xib */; };
 		A490AC4E27DD945E00B04CE1 /* NoteListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A490AC4D27DD945E00B04CE1 /* NoteListViewController.swift */; };
 		A490AC5027DD9D2E00B04CE1 /* NoteListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A490AC4F27DD9D2E00B04CE1 /* NoteListViewModel.swift */; };
 		A490AC5527DDA0CA00B04CE1 /* NoteCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A490AC5327DDA0CA00B04CE1 /* NoteCell.swift */; };
@@ -83,6 +86,9 @@
 		A459003B27E9C5C9003010A0 /* CGSize+Area.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGSize+Area.swift"; sourceTree = "<group>"; };
 		A467B5C727DA258700AC702D /* NewNoteDatePickerRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNoteDatePickerRowView.swift; sourceTree = "<group>"; };
 		A467B5C927DA289500AC702D /* NewNoteDatePickerRowView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NewNoteDatePickerRowView.xib; sourceTree = "<group>"; };
+		A48E183927E71D9300B44477 /* UILabel+ParagraphStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+ParagraphStyle.swift"; sourceTree = "<group>"; };
+		A48E183B27E7379100B44477 /* CapsuleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapsuleButton.swift; sourceTree = "<group>"; };
+		A48E183D27E737B600B44477 /* CapsuleButton.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CapsuleButton.xib; sourceTree = "<group>"; };
 		A490AC4D27DD945E00B04CE1 /* NoteListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteListViewController.swift; sourceTree = "<group>"; };
 		A490AC4F27DD9D2E00B04CE1 /* NoteListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteListViewModel.swift; sourceTree = "<group>"; };
 		A490AC5327DDA0CA00B04CE1 /* NoteCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteCell.swift; sourceTree = "<group>"; };
@@ -224,6 +230,7 @@
 			children = (
 				A817430027C112D00016C921 /* DefaultButton.swift */,
 				A4CF2C7F27C733FE001B01B1 /* ColorButton.swift */,
+				A48E183B27E7379100B44477 /* CapsuleButton.swift */,
 			);
 			path = Button;
 			sourceTree = "<group>";
@@ -264,6 +271,7 @@
 				A467B5C927DA289500AC702D /* NewNoteDatePickerRowView.xib */,
 				A8FC07D227B3ECF30077A758 /* LaunchScreen.storyboard */,
 				A8ECD4A427E30FF300886BC0 /* BottleCell.xib */,
+				A48E183D27E737B600B44477 /* CapsuleButton.xib */,
 			);
 			path = Storyboard;
 			sourceTree = "<group>";
@@ -299,6 +307,7 @@
 				A4C1AFCD27E4F8150096CD3E /* UIView+FadeInOut.swift */,
 				A4C1AFD327E5E6120096CD3E /* UITextView+ParagraphStyle.swift */,
 				A459003B27E9C5C9003010A0 /* CGSize+Area.swift */,
+				A48E183927E71D9300B44477 /* UILabel+ParagraphStyle.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -423,6 +432,7 @@
 				A8FC07DD27B3EF030077A758 /* .swiftlint.yml in Resources */,
 				A467B5CA27DA289600AC702D /* NewNoteDatePickerRowView.xib in Resources */,
 				A8FC07D427B3ECF30077A758 /* LaunchScreen.storyboard in Resources */,
+				A48E183E27E737B600B44477 /* CapsuleButton.xib in Resources */,
 				A8FC07D127B3ECF30077A758 /* Assets.xcassets in Resources */,
 				A8FC07CF27B3ECF00077A758 /* Main.storyboard in Resources */,
 				A4F5715227DB715100E7DF9B /* ColorButton.xib in Resources */,
@@ -477,8 +487,10 @@
 				A819CF9F27DDD97C00DE8E72 /* HapticManager.swift in Sources */,
 				A8ECD4A727E33BFA00886BC0 /* BottleListViewModel.swift in Sources */,
 				A843332427DA397800A12A54 /* DataProvider.swift in Sources */,
+				A48E183A27E71D9300B44477 /* UILabel+ParagraphStyle.swift in Sources */,
 				A4B2860B27D9B434008769EB /* UIViewController+FadeOut.swift in Sources */,
 				A4B2860927D9A56A008769EB /* NewNoteTextViewController.swift in Sources */,
+				A48E183C27E7379100B44477 /* CapsuleButton.swift in Sources */,
 				A843332127DA026D00A12A54 /* NewBottleDatePickerViewController.swift in Sources */,
 				A8FC07CA27B3ECF00077A758 /* SceneDelegate.swift in Sources */,
 				A4F5715427DB8B6500E7DF9B /* NewNote.swift in Sources */,
@@ -576,6 +588,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -637,6 +650,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/Happiggy-bank/Happiggy-bank/Assets.xcassets/note-images/noteGreen.imageset/Contents.json
+++ b/Happiggy-bank/Happiggy-bank/Assets.xcassets/note-images/noteGreen.imageset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "초록.svg",
+      "filename" : "초록.svg",
       "idiom" : "universal"
     }
   ],

--- a/Happiggy-bank/Happiggy-bank/Assets.xcassets/note-images/notePink.imageset/Contents.json
+++ b/Happiggy-bank/Happiggy-bank/Assets.xcassets/note-images/notePink.imageset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "분홍.svg",
+      "filename" : "분홍.svg",
       "idiom" : "universal"
     }
   ],

--- a/Happiggy-bank/Happiggy-bank/Assets.xcassets/note-images/notePurple.imageset/Contents.json
+++ b/Happiggy-bank/Happiggy-bank/Assets.xcassets/note-images/notePurple.imageset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "보라.svg",
+      "filename" : "보라.svg",
       "idiom" : "universal"
     }
   ],

--- a/Happiggy-bank/Happiggy-bank/Assets.xcassets/note-images/noteWhite.imageset/Contents.json
+++ b/Happiggy-bank/Happiggy-bank/Assets.xcassets/note-images/noteWhite.imageset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "하양.svg",
+      "filename" : "하양.svg",
       "idiom" : "universal"
     }
   ],

--- a/Happiggy-bank/Happiggy-bank/Assets.xcassets/note-images/noteYellow.imageset/Contents.json
+++ b/Happiggy-bank/Happiggy-bank/Assets.xcassets/note-images/noteYellow.imageset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "노랑.svg",
+      "filename" : "노랑.svg",
       "idiom" : "universal"
     }
   ],

--- a/Happiggy-bank/Happiggy-bank/Button/CapsuleButton.swift
+++ b/Happiggy-bank/Happiggy-bank/Button/CapsuleButton.swift
@@ -1,0 +1,65 @@
+//
+//  CapsuleButton.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/03/20.
+//
+
+import UIKit
+
+/// 캡슐 모양 테두리를 갖는 버튼
+final class CapsuleButton: UIButton {
+    
+    // MARK: - @IBOulet
+    
+    /// 제목 라벨의 상위 뷰로 캡슐 모양 테두리를 나타낼 뷰
+    @IBOutlet weak var contentView: UIView!
+    
+    /// 제목 라벨
+    @IBOutlet weak var textLabel: UILabel!
+    
+    
+    // MARK: - Inits
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.commonInit()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        
+        self.commonInit()
+    }
+    
+    
+    // MARK: - Functions
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        self.makeCapsuleBorder()
+    }
+    
+    /// init 시 해야하는 공통 작업
+    private func commonInit() {
+        self.loadAndConfigureXib()
+        self.makeCapsuleBorder()
+    }
+    
+    /// xib 파일 로딩하고 관련 설정
+    private func loadAndConfigureXib() {
+        Bundle.main.loadNibNamed(CapsuleButton.name, owner: self, options: nil)
+        self.addSubview(self.contentView)
+        self.contentView.frame = self.bounds
+        self.contentView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    }
+    
+    /// 캡슐 모양 테두리 설정
+    private func makeCapsuleBorder() {
+        self.contentView.layer.cornerRadius = self.frame.height / 2
+        self.contentView.layer.borderWidth = Metric.borderWidth
+        self.contentView.layer.borderColor = UIColor.customSecondaryLabel.cgColor
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/Extensions/UILabel+ParagraphStyle.swift
+++ b/Happiggy-bank/Happiggy-bank/Extensions/UILabel+ParagraphStyle.swift
@@ -1,0 +1,46 @@
+//
+//  UILabel+ParagraphStyle.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/03/20.
+//
+
+import UIKit
+
+extension UILabel {
+    
+    /// 자간, 행간, 폰트 설정 메서드
+    func configureParagraphStyle(
+        lineSpacing: CGFloat? = nil,
+        characterSpacing: CGFloat? = nil,
+        font: UIFont? = nil
+    ) {
+        var mutableAttributedString = self.attributedText?.mutableCopy()
+                                        as? NSMutableAttributedString
+        if mutableAttributedString == nil {
+            mutableAttributedString = self.text?.nsMutableAttributedStringify()
+        }
+        
+        guard let mutableAttributedString = mutableAttributedString
+        else { return }
+        
+        let lineSpacing = (lineSpacing == nil) ? .zero : lineSpacing!
+        let characterSpacing = (characterSpacing == nil) ? .zero : characterSpacing!
+        let font: UIFont = (font == nil) ? (self.font ?? UIFont()) : font!
+        
+        let paragraphStyle = NSMutableParagraphStyle().then {
+            $0.lineSpacing = lineSpacing
+        }
+        
+        mutableAttributedString.addAttributes(
+            [
+                .paragraphStyle: paragraphStyle,
+                .font: font,
+                .kern: characterSpacing
+            ],
+            range: NSRange(location: .zero, length: mutableAttributedString.length)
+        )
+        
+        self.attributedText = mutableAttributedString
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -129,7 +129,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="QYn-0Q-jnc">
-                                <rect key="frame" x="0.0" y="88" width="375" height="690"/>
+                                <rect key="frame" x="0.0" y="144" width="375" height="585"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="NoteCell" id="1iU-C4-Ykx" customClass="NoteCell" customModule="Happiggy_bank" customModuleProvider="target">
@@ -146,24 +146,52 @@
                                     <outlet property="delegate" destination="KE3-2Z-kiH" id="9ol-Mz-6fU"/>
                                 </connections>
                             </tableView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="365개의 행복" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LKi-g0-POm">
+                                <rect key="frame" x="24" y="106" width="94" height="20.333333333333329"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" name="customGray"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PBH-Sc-J25" customClass="CapsuleButton" customModule="Happiggy_bank" customModuleProvider="target">
+                                <rect key="frame" x="321" y="100" width="30" height="32"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="tintColor" name="secondaryLabelColor"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal">
+                                    <color key="titleColor" name="secondaryLabelColor"/>
+                                </state>
+                                <connections>
+                                    <action selector="openAllNotesButtonDidTap:" destination="KE3-2Z-kiH" eventType="touchUpInside" id="VxI-Mw-Rpy"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="dO5-e2-qa6"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="QYn-0Q-jnc" firstAttribute="top" secondItem="dO5-e2-qa6" secondAttribute="top" id="DZZ-fW-GOZ"/>
+                            <constraint firstItem="QYn-0Q-jnc" firstAttribute="top" secondItem="dO5-e2-qa6" secondAttribute="top" constant="56" id="DZZ-fW-GOZ"/>
                             <constraint firstItem="dO5-e2-qa6" firstAttribute="trailing" secondItem="QYn-0Q-jnc" secondAttribute="trailing" id="KxE-qy-Adj"/>
+                            <constraint firstItem="PBH-Sc-J25" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="LKi-g0-POm" secondAttribute="trailing" priority="250" constant="8" symbolic="YES" id="R8p-Dn-tcz"/>
+                            <constraint firstItem="dO5-e2-qa6" firstAttribute="trailing" secondItem="PBH-Sc-J25" secondAttribute="trailing" constant="24" id="VUS-VU-gQ5"/>
                             <constraint firstItem="QYn-0Q-jnc" firstAttribute="leading" secondItem="dO5-e2-qa6" secondAttribute="leading" id="Vnt-XQ-Bt4"/>
+                            <constraint firstItem="PBH-Sc-J25" firstAttribute="top" secondItem="dO5-e2-qa6" secondAttribute="top" constant="12" id="WYg-vh-hXn"/>
+                            <constraint firstItem="QYn-0Q-jnc" firstAttribute="top" secondItem="PBH-Sc-J25" secondAttribute="bottom" constant="12" id="Xpb-pp-nT7"/>
+                            <constraint firstItem="LKi-g0-POm" firstAttribute="leading" secondItem="dO5-e2-qa6" secondAttribute="leading" constant="24" id="jwh-PH-Zgf"/>
                             <constraint firstItem="dO5-e2-qa6" firstAttribute="bottom" secondItem="QYn-0Q-jnc" secondAttribute="bottom" id="nDq-ev-SEG"/>
+                            <constraint firstItem="LKi-g0-POm" firstAttribute="centerY" secondItem="PBH-Sc-J25" secondAttribute="centerY" id="qgW-Jw-Qrc"/>
                         </constraints>
                     </view>
+                    <toolbarItems/>
                     <navigationItem key="navigationItem" id="6cw-er-3yd"/>
+                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
+                        <outlet property="noteCountLabel" destination="LKi-g0-POm" id="kqy-xQ-oFd"/>
+                        <outlet property="openAllNotesButton" destination="PBH-Sc-J25" id="0GZ-5Z-Sfe"/>
                         <outlet property="tableView" destination="QYn-0Q-jnc" id="hjF-0v-h7m"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="2zj-Wn-JrU" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="892" y="2446"/>
+            <point key="canvasLocation" x="892" y="2445.8128078817736"/>
         </scene>
         <!--Home-->
         <scene sceneID="YE7-1s-WX3">
@@ -307,9 +335,9 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Xam-7g-OPV"/>
                         <constraints>
-                            <constraint firstItem="x5u-uo-squ" firstAttribute="top" secondItem="Xam-7g-OPV" secondAttribute="top" id="0Jm-aw-g2w"/>
+                            <constraint firstItem="x5u-uo-squ" firstAttribute="top" secondItem="sBx-5w-9Me" secondAttribute="top" constant="44" id="0Jm-aw-g2w"/>
                             <constraint firstAttribute="trailing" secondItem="ecq-uy-9fg" secondAttribute="trailing" id="1Rn-06-dXq"/>
-                            <constraint firstItem="x5u-uo-squ" firstAttribute="leading" secondItem="Xam-7g-OPV" secondAttribute="leading" id="1ff-Tv-2kf"/>
+                            <constraint firstItem="x5u-uo-squ" firstAttribute="leading" secondItem="sBx-5w-9Me" secondAttribute="leading" id="1ff-Tv-2kf"/>
                             <constraint firstItem="bI2-ak-dCN" firstAttribute="centerX" secondItem="sBx-5w-9Me" secondAttribute="centerX" id="7XD-ch-KDR"/>
                             <constraint firstItem="ecq-uy-9fg" firstAttribute="top" secondItem="sBx-5w-9Me" secondAttribute="top" id="9Io-pv-JfF"/>
                             <constraint firstItem="JzG-sV-z0R" firstAttribute="top" secondItem="x5u-uo-squ" secondAttribute="bottom" constant="140" id="Alo-zq-zpA"/>
@@ -318,7 +346,7 @@
                             <constraint firstItem="JzG-sV-z0R" firstAttribute="centerX" secondItem="bI2-ak-dCN" secondAttribute="centerX" id="YPc-m7-Ckd"/>
                             <constraint firstItem="x1u-nY-DW6" firstAttribute="top" secondItem="bI2-ak-dCN" secondAttribute="bottom" constant="32" id="bvZ-nW-Oss"/>
                             <constraint firstItem="bI2-ak-dCN" firstAttribute="centerY" secondItem="sBx-5w-9Me" secondAttribute="centerY" id="dvP-OM-mIk"/>
-                            <constraint firstItem="x5u-uo-squ" firstAttribute="trailing" secondItem="Xam-7g-OPV" secondAttribute="trailing" id="hld-b3-XZk"/>
+                            <constraint firstItem="x5u-uo-squ" firstAttribute="trailing" secondItem="sBx-5w-9Me" secondAttribute="trailing" id="hld-b3-XZk"/>
                             <constraint firstItem="ecq-uy-9fg" firstAttribute="leading" secondItem="sBx-5w-9Me" secondAttribute="leading" id="nGs-xg-N4u"/>
                         </constraints>
                     </view>
@@ -365,13 +393,13 @@
                                 </items>
                             </navigationBar>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="GeA-rS-UHc">
-                                <rect key="frame" x="0.0" y="88" width="375" height="400"/>
+                                <rect key="frame" x="0.0" y="88" width="375" height="390"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="400" id="8gy-me-kK7"/>
+                                    <constraint firstAttribute="height" constant="390" id="8gy-me-kK7"/>
                                 </constraints>
                             </imageView>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="fvK-sf-BF4">
-                                <rect key="frame" x="19" y="172.66666666666663" width="332" height="227.33333333333337"/>
+                                <rect key="frame" x="19" y="172.66666666666663" width="332" height="217.33333333333337"/>
                                 <color key="textColor" systemColor="labelColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="19"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -401,7 +429,7 @@
                                 </connections>
                             </stackView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aQ3-jl-6Wm" userLabel="ColorButton" customClass="ColorButton" customModule="Happiggy_bank" customModuleProvider="target">
-                                <rect key="frame" x="24" y="424" width="40" height="40"/>
+                                <rect key="frame" x="24" y="414" width="40" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="40" id="6fW-ne-2bf"/>
                                     <constraint firstAttribute="height" constant="40" id="eig-xC-7Gx"/>
@@ -411,7 +439,7 @@
                                 </connections>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0/100" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HX4-ny-KZ7" userLabel="LetterCountLabel">
-                                <rect key="frame" x="307.66666666666669" y="434" width="43.333333333333314" height="20.333333333333314"/>
+                                <rect key="frame" x="307.66666666666669" y="424" width="43.333333333333314" height="20.333333333333314"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -427,8 +455,8 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="fvK-sf-BF4" firstAttribute="leading" secondItem="Qg8-yI-fTV" secondAttribute="leading" constant="-5" id="FRT-hw-tFd"/>
-                            <constraint firstItem="Rms-YT-wWN" firstAttribute="top" secondItem="bn6-rM-p0H" secondAttribute="top" id="Gyw-ql-9vl"/>
-                            <constraint firstItem="Rms-YT-wWN" firstAttribute="leading" secondItem="bn6-rM-p0H" secondAttribute="leading" id="LBS-sy-BL8"/>
+                            <constraint firstItem="Rms-YT-wWN" firstAttribute="top" secondItem="1PQ-Bn-66w" secondAttribute="top" constant="44" id="Gyw-ql-9vl"/>
+                            <constraint firstItem="Rms-YT-wWN" firstAttribute="leading" secondItem="1PQ-Bn-66w" secondAttribute="leading" id="LBS-sy-BL8"/>
                             <constraint firstItem="HX4-ny-KZ7" firstAttribute="centerY" secondItem="aQ3-jl-6Wm" secondAttribute="centerY" id="Sfu-bF-AIC"/>
                             <constraint firstItem="GeA-rS-UHc" firstAttribute="trailing" secondItem="bn6-rM-p0H" secondAttribute="trailing" id="blO-Yz-toF"/>
                             <constraint firstItem="fvK-sf-BF4" firstAttribute="top" secondItem="Qg8-yI-fTV" secondAttribute="bottom" constant="16" id="buI-x5-kRu"/>
@@ -445,7 +473,7 @@
                             <constraint firstItem="Qg8-yI-fTV" firstAttribute="top" secondItem="Rms-YT-wWN" secondAttribute="bottom" constant="24" id="u1Q-xA-r8X"/>
                             <constraint firstItem="fvK-sf-BF4" firstAttribute="trailing" secondItem="GeA-rS-UHc" secondAttribute="trailing" constant="-24" id="yfR-Cy-RSM"/>
                             <constraint firstItem="GeA-rS-UHc" firstAttribute="leading" secondItem="bn6-rM-p0H" secondAttribute="leading" id="zHW-UQ-8kk"/>
-                            <constraint firstItem="Rms-YT-wWN" firstAttribute="trailing" secondItem="bn6-rM-p0H" secondAttribute="trailing" id="zQB-22-wf2"/>
+                            <constraint firstItem="Rms-YT-wWN" firstAttribute="trailing" secondItem="1PQ-Bn-66w" secondAttribute="trailing" id="zQB-22-wf2"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="OdQ-rH-b8B"/>
@@ -535,7 +563,7 @@
                                 <rect key="frame" x="0.0" y="44" width="375" height="44"/>
                                 <items>
                                     <navigationItem id="DM1-Z5-JBN">
-                                        <barButtonItem key="leftBarButtonItem" title="Back" image="chevron.left" catalog="system" id="CIr-tB-YaV">
+                                        <barButtonItem key="leftBarButtonItem" title="Back" image="xmark" catalog="system" id="CIr-tB-YaV">
                                             <connections>
                                                 <action selector="backButtonDidTap:" destination="g5l-hv-0de" id="pas-6F-NnN"/>
                                             </connections>
@@ -552,16 +580,16 @@
                         <viewLayoutGuide key="safeArea" id="0NK-Mm-KBY"/>
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="8FB-Yv-nda" secondAttribute="bottom" id="1fz-6y-srW"/>
-                            <constraint firstItem="MqT-Ah-3Uq" firstAttribute="leading" secondItem="0NK-Mm-KBY" secondAttribute="leading" id="1wD-UR-C5a"/>
+                            <constraint firstItem="MqT-Ah-3Uq" firstAttribute="leading" secondItem="t95-o1-XLO" secondAttribute="leading" id="1wD-UR-C5a"/>
                             <constraint firstItem="BKz-1X-hoY" firstAttribute="leading" secondItem="t95-o1-XLO" secondAttribute="leadingMargin" constant="24" id="68I-Pw-O3M"/>
-                            <constraint firstItem="MqT-Ah-3Uq" firstAttribute="top" secondItem="0NK-Mm-KBY" secondAttribute="top" id="7Rx-Tn-DMY"/>
+                            <constraint firstItem="MqT-Ah-3Uq" firstAttribute="top" secondItem="t95-o1-XLO" secondAttribute="top" constant="44" id="7Rx-Tn-DMY"/>
                             <constraint firstAttribute="trailingMargin" secondItem="BKz-1X-hoY" secondAttribute="trailing" constant="24" id="B00-RW-oW7"/>
                             <constraint firstAttribute="trailing" secondItem="8FB-Yv-nda" secondAttribute="trailing" id="Q47-I3-k4l"/>
                             <constraint firstItem="8FB-Yv-nda" firstAttribute="leading" secondItem="t95-o1-XLO" secondAttribute="leading" id="Xjv-R1-yEA"/>
                             <constraint firstItem="BKz-1X-hoY" firstAttribute="centerY" secondItem="t95-o1-XLO" secondAttribute="centerY" id="gtY-Bc-XA0"/>
                             <constraint firstItem="BKz-1X-hoY" firstAttribute="centerX" secondItem="t95-o1-XLO" secondAttribute="centerX" id="hzI-gP-J3g"/>
                             <constraint firstItem="8FB-Yv-nda" firstAttribute="top" secondItem="t95-o1-XLO" secondAttribute="top" id="o4I-A9-Npz"/>
-                            <constraint firstItem="MqT-Ah-3Uq" firstAttribute="trailing" secondItem="0NK-Mm-KBY" secondAttribute="trailing" id="yWV-eM-fPO"/>
+                            <constraint firstItem="MqT-Ah-3Uq" firstAttribute="trailing" secondItem="t95-o1-XLO" secondAttribute="trailing" id="yWV-eM-fPO"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="7jK-EQ-u4a"/>
@@ -738,6 +766,9 @@
         <image name="xmark" catalog="system" width="128" height="113"/>
         <namedColor name="customGray">
             <color red="0.59999999999999998" green="0.59999999999999998" blue="0.59999999999999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="secondaryLabelColor">
+            <color red="0.33333333333333331" green="0.60392156862745094" blue="0.75294117647058822" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="warningLabelColor">
             <color red="1" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Happiggy-bank/Happiggy-bank/Storyboard/CapsuleButton.xib
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/CapsuleButton.xib
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CapsuleButton" customModule="Happiggy_bank" customModuleProvider="target">
+            <connections>
+                <outlet property="contentView" destination="uc2-dG-Sbq" id="spx-8c-li4"/>
+                <outlet property="textLabel" destination="P6l-Wo-Uqz" id="9PS-eq-mDV"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view userInteractionEnabled="NO" contentMode="scaleToFill" id="uc2-dG-Sbq">
+            <rect key="frame" x="0.0" y="0.0" width="189" height="79"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="전체 개봉" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="P6l-Wo-Uqz">
+                    <rect key="frame" x="12" y="5" width="165" height="69"/>
+                    <color key="tintColor" name="secondaryLabelColor"/>
+                    <accessibility key="accessibilityConfiguration">
+                        <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
+                    </accessibility>
+                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                    <color key="textColor" name="secondaryLabelColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <color key="tintColor" name="secondaryLabelColor"/>
+            <accessibility key="accessibilityConfiguration">
+                <accessibilityTraits key="traits" notEnabled="YES"/>
+            </accessibility>
+            <constraints>
+                <constraint firstAttribute="bottom" secondItem="P6l-Wo-Uqz" secondAttribute="bottom" constant="5" id="2yK-1V-JeO"/>
+                <constraint firstAttribute="trailing" secondItem="P6l-Wo-Uqz" secondAttribute="trailing" constant="12" id="3Bs-oh-bar"/>
+                <constraint firstItem="P6l-Wo-Uqz" firstAttribute="top" secondItem="uc2-dG-Sbq" secondAttribute="top" constant="5" id="k6i-qc-RZb"/>
+                <constraint firstItem="P6l-Wo-Uqz" firstAttribute="leading" secondItem="uc2-dG-Sbq" secondAttribute="leading" constant="12" id="yog-Kq-kkI"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="-136.95652173913044" y="-961.94196428571422"/>
+        </view>
+    </objects>
+    <resources>
+        <namedColor name="secondaryLabelColor">
+            <color red="0.33333333333333331" green="0.60392156862745094" blue="0.75294117647058822" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Happiggy-bank/Happiggy-bank/Subview/NoteCell.swift
+++ b/Happiggy-bank/Happiggy-bank/Subview/NoteCell.swift
@@ -22,7 +22,20 @@ final class NoteCell: UITableViewCell {
     @IBOutlet weak var backDateLabel: UILabel!
     
     /// 뒷면에 나타날 쪽지 내용
-    @IBOutlet weak var contentLabel: UILabel!
+    @IBOutlet weak var contentLabel: UILabel! {
+        didSet {
+            self.contentLabel.configureParagraphStyle(
+                lineSpacing: Metric.lineSpacing,
+                characterSpacing: Metric.characterSpacing
+            )
+        }
+    }
+    
+    /// 애니메이션 딜레이 시간: 디폴트 0
+    var animationDelay: TimeInterval = .zero
+    
+    /// 애니메이션 후 실행할 작업
+    var completion: ((Bool) -> Void)?
     
     
     // MARK: - Function
@@ -68,7 +81,10 @@ final class NoteCell: UITableViewCell {
         /// 이동 효과 주기 위해 프레임을 가운데로 변경
         self.backDateLabel.frame = self.frontDateLabel.frame
 
-        UIView.animateKeyframes(withDuration: Metric.animationDuration, delay: .zero) {
+        UIView.animateKeyframes(
+            withDuration: Metric.animationDuration,
+            delay: self.animationDelay
+        ) {
             /// 날짜 라벨 이동 애니메이션
             UIView.addKeyframe(withRelativeStartTime: .zero, relativeDuration: Metric.half) {
                 self.layoutIfNeeded()
@@ -77,6 +93,12 @@ final class NoteCell: UITableViewCell {
             UIView.addKeyframe(withRelativeStartTime: Metric.half, relativeDuration: Metric.half) {
                 self.contentLabel.alpha = .one
             }
+        } completion: { result in
+            guard let completion = self.completion else {
+                return
+            }
+            
+            completion(result)
         }
     }
 }

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -533,12 +533,28 @@ extension NoteListViewController {
         
         /// note cell 높이 : 쪽지 이미지 높이 + spacing
         static let cellHeight = noteImageHeight + noteImageSpacing
+        
+        /// 애니메이션 딜레이 시간: 0.5
+        static let animationDelay: TimeInterval = 0.5
 
         /// note cell 세로:가로 비율 : 242/327
         private static let noteImageSizeRatio: CGFloat = 242/327
         
         /// 쪽지 이미지 사이 간격: 16
         private static let noteImageSpacing: CGFloat = 16
+    }
+    
+    /// NoteNoteDatePickerViewModel 에서 사용하는 문자열
+    enum StringLiteral {
+        
+        /// 알림 제목
+        static let alertTitle = "전체 쪽지를 개봉하시겠습니까?"
+        
+        /// 취소 버튼 제목
+        static let cancelButtonTitle = "아니오"
+        
+        /// 확인 버튼 제목
+        static let confirmButtonTitle = "네"
     }
 }
 
@@ -555,6 +571,12 @@ extension NoteCell {
         
         /// 좌우 패딩: 25
         static let horizontalPadding = NoteListViewController.Metric.horizontalPadding
+        
+        /// 내용 라벨 줄 간격: 8
+        static let lineSpacing: CGFloat = 8
+        
+        /// 내용 라벨 자간: 0.5
+        static let characterSpacing: CGFloat = 0.5
     }
 }
 
@@ -589,7 +611,7 @@ extension NewNoteTextViewController {
             let navigationBarHeight = navigationBarFrame.size.height
             let screenHeight = UIScreen.main.bounds.height
             let safeAreaTopInset = navigationBarFrame.origin.y
-            
+
             return screenHeight - safeAreaTopInset - navigationBarHeight - keyboardHeight
         }
         
@@ -615,7 +637,6 @@ extension NewNoteDatePickerViewModel {
         
         /// 날짜라벨 폰트 크기: 17
         static let dateLabelFontSize: CGFloat = 17
-        
     }
 }
 
@@ -636,7 +657,10 @@ extension NoteListViewModel {
         static let emptyString = ""
         
         /// 쪽지 이미지 에셋 호출을 위해 앞에 붙일 접두사
-        static var listNote: String = "listNote"
+        static let listNote: String = "listNote"
+        
+        /// 쪽지 개수 라벨에서 개수 뒤에 붙일 문자열: 리턴 "행복 n개"
+        static func noteCountLabelString(count: Int) -> String { "행복 \(count)개" }
     }
 }
 
@@ -661,5 +685,15 @@ extension NewNoteTextViewModel {
         
         /// 글자수 라벨 폰트 크기: 17
         static let letterCountLabel = dateLabel
+    }
+}
+
+extension CapsuleButton {
+    
+    /// CapsuleButton 에서 사용하는 상수
+    enum Metric {
+        
+        /// 외곽선 굵기: 1
+        static let borderWidth: CGFloat = 1
     }
 }

--- a/Happiggy-bank/Happiggy-bank/ViewModel/NoteListViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/NoteListViewModel.swift
@@ -15,6 +15,16 @@ final class NoteListViewModel {
     /// 리스트에서 나타낼 쪽지들의 배열
     var notes: [Note]!
     
+    /// 모든 쪽지가 다 개봉되었는지 여부
+    var allNotesAreOpen: Bool {
+        self.notes.first { !$0.isOpen } == nil ? true : false
+    }
+    
+    /// 개봉하지 않은 쪽지들
+    var enumeratedUnopenNotes: [(offset: Int, element: Note)] {
+        self.notes.enumerated().filter { !$1.isOpen }
+    }
+    
     /// 유리병 제목
     private(set) lazy var bottleTitle: String = {
         self.notes.first?.bottle.title ?? StringLiteral.emptyString
@@ -23,6 +33,11 @@ final class NoteListViewModel {
     /// 쪽지 전체 개수
     private(set) lazy var numberOfTotalNotes: Int = {
         self.notes.count
+    }()
+    
+    /// 쪽지 개수 라벨 문자열
+    private(set) lazy var noteCountLabelString: String = {
+        StringLiteral.noteCountLabelString(count: self.numberOfTotalNotes)
     }()
     
     


### PR DESCRIPTION
## 반영 내용
- 이슈 #54 
- 이슈 #55 
- 이슈 #58 
- 이슈 #35 

<br>

### NoteListViewController 
- 전체 개봉 버튼을 누르면 알림을 띄워서 다시 한 번 확인하도록 함
- 전체 개봉 시 현재 보이는 쪽지는 애니메이션과 함께 개봉되고 나머지는 바로 효과 없이 개봉되도록 처리 + 개봉 후 버튼 숨김
  - 처음에는 전부 reloadRows 로 했으나 로딩이 오래걸리는 문제가 있어 보이는 쪽지만 reloadRows 로 바꿈
- 라벨 행간, 자간 조정
  - extension으로 빼둬서 쓸 일 있으시면 바로 쓰시면 됩니당!


<br>