### PR TITLE
[feat] 쪽지 리스트 컬렉션 뷰로 변경, fetched result controller 적용 #72 #73

### DIFF
--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A425F8B627EDF4FB00A005AB /* TagViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A425F8B527EDF4FB00A005AB /* TagViewFlowLayout.swift */; };
+		A425F8B827EDF59A00A005AB /* TagCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A425F8B727EDF59A00A005AB /* TagCell.swift */; };
 		A44E901727D5EB130053AC57 /* Happiggy-bank.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = A44E901527D5EB130053AC57 /* Happiggy-bank.xcdatamodeld */; };
 		A456657C27CC66FD007CF70A /* DefaultButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A817430027C112D00016C921 /* DefaultButton.swift */; };
 		A456657E27CC77A9007CF70A /* Date+Formatted.swift in Sources */ = {isa = PBXBuildFile; fileRef = A456657D27CC77A9007CF70A /* Date+Formatted.swift */; };
@@ -80,6 +82,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		A425F8B527EDF4FB00A005AB /* TagViewFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagViewFlowLayout.swift; sourceTree = "<group>"; };
+		A425F8B727EDF59A00A005AB /* TagCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagCell.swift; sourceTree = "<group>"; };
 		A44E901627D5EB130053AC57 /* Happigy-bank.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Happigy-bank.xcdatamodel"; sourceTree = "<group>"; };
 		A456657D27CC77A9007CF70A /* Date+Formatted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Formatted.swift"; sourceTree = "<group>"; };
 		A459003927E95D6B003010A0 /* Grid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Grid.swift; sourceTree = "<group>"; };
@@ -221,6 +225,7 @@
 				A89CBEDA27CBDD99005549F6 /* BottleCell.swift */,
 				A490AC5327DDA0CA00B04CE1 /* NoteCell.swift */,
 				D2C48C0027E9DFA1006FC59E /* NoteView.swift */,
+				A425F8B727EDF59A00A005AB /* TagCell.swift */,
 			);
 			path = Subview;
 			sourceTree = "<group>";
@@ -258,6 +263,7 @@
 				A819CF9E27DDD97C00DE8E72 /* HapticManager.swift */,
 				D2C48BFE27E9D60A006FC59E /* Gravity.swift */,
 				A459003927E95D6B003010A0 /* Grid.swift */,
+				A425F8B527EDF4FB00A005AB /* TagViewFlowLayout.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -466,6 +472,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A425F8B827EDF59A00A005AB /* TagCell.swift in Sources */,
 				A4B2860F27D9F539008769EB /* NewNoteDatePickerViewModel.swift in Sources */,
 				A467B5C827DA258700AC702D /* NewNoteDatePickerRowView.swift in Sources */,
 				A4C1AFD227E5C60E0096CD3E /* NewNoteTextViewModel.swift in Sources */,
@@ -508,6 +515,7 @@
 				A8EB5E8B27C8B087005704F2 /* UIButton+Extension.swift in Sources */,
 				A843331F27DA013800A12A54 /* NewBottleNameFieldViewController.swift in Sources */,
 				A459003C27E9C5C9003010A0 /* CGSize+Area.swift in Sources */,
+				A425F8B627EDF4FB00A005AB /* TagViewFlowLayout.swift in Sources */,
 				A4C1AFC427E47DC50096CD3E /* String+NSMutableAttributedStringify.swift in Sources */,
 				A4C1AFC027E477180096CD3E /* NSMutableAttributedString+ColorBold.swift in Sources */,
 				A491018F27D735920012DFDD /* Note+CoreDataClass.swift in Sources */,

--- a/Happiggy-bank/Happiggy-bank/CoreData/Note+CoreDataClass.swift
+++ b/Happiggy-bank/Happiggy-bank/CoreData/Note+CoreDataClass.swift
@@ -24,6 +24,35 @@ public class Note: NSManagedObject {
         return note
     }
     
+    /// sortDescriptor 를 설정하지 않으면 (생성 날짜) 최신순으로 정렬
+    static func fetchRequest(
+        predicate: NSPredicate,
+        sortDescriptor: [NSSortDescriptor] = [NSSortDescriptor(
+            key: "date_",
+            ascending: false
+        )]
+    ) -> NSFetchRequest<Note> {
+        NSFetchRequest<Note>(entityName: Note.name).then {
+            $0.predicate = predicate
+            $0.sortDescriptors = sortDescriptor
+        }
+    }
+    
+    /// 저금통의 모든 쪽지를 호출하는 리퀘스트로 순서를 지정하지 않으면 날짜가 빠른 순으로 정렬
+    static func fetchRequest(
+        bottle: Bottle,
+        sortDescriptor: [NSSortDescriptor] = [NSSortDescriptor(
+            key: "date_",
+            ascending: false
+        )]
+    ) -> NSFetchRequest<Note> {
+        NSFetchRequest<Note>(entityName: Note.name).then {
+            $0.sortDescriptors = sortDescriptor
+            $0.predicate = NSPredicate(format: "bottle_ == %@", argumentArray: [bottle])
+            $0.sortDescriptors = sortDescriptor
+        }
+    }
+    
     
     // MARK: - Init(s)
     
@@ -57,4 +86,19 @@ public class Note: NSManagedObject {
     
     /// 담겨있는 저금통
     var bottle: Bottle { self.bottle_ ?? Bottle() }
+    
+    /// 내용의 첫 번째 유효한 단어
+    var firstWord: String {
+        
+        var firstWord = self.content
+            .components(separatedBy: NSCharacterSet.whitespacesAndNewlines)
+            .first { !$0.isEmpty } ?? .empty
+
+        /// 첫 단어가 10글자를 넘으면 10글자까지만 자름
+        if firstWord.count > Metric.firstWordMaxLength {
+            firstWord = String(firstWord.prefix(Metric.firstWordMaxLength))
+        }
+        
+        return firstWord
+    }
 }

--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -7,6 +7,7 @@
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -127,65 +128,45 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="QYn-0Q-jnc">
-                                <rect key="frame" x="0.0" y="144" width="375" height="585"/>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="SCP-Hp-DbX">
+                                <rect key="frame" x="24" y="88" width="327" height="641"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="NoteCell" id="1iU-C4-Ykx" customClass="NoteCell" customModule="Happiggy_bank" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="44.666666030883789" width="375" height="44"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="1iU-C4-Ykx" id="S15-cC-Gxi">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="22E-Nu-lTg">
+                                    <size key="itemSize" width="128" height="128"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="cell" id="CtU-HV-3BA">
+                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="mMj-FT-KQ4">
+                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                             <autoresizingMask key="autoresizingMask"/>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                </prototypes>
+                                        </collectionViewCellContentView>
+                                    </collectionViewCell>
+                                </cells>
                                 <connections>
-                                    <outlet property="dataSource" destination="KE3-2Z-kiH" id="9Bk-6o-K3E"/>
-                                    <outlet property="delegate" destination="KE3-2Z-kiH" id="9ol-Mz-6fU"/>
+                                    <outlet property="dataSource" destination="KE3-2Z-kiH" id="kDT-Br-WaX"/>
+                                    <outlet property="delegate" destination="KE3-2Z-kiH" id="Hvc-RB-HVQ"/>
                                 </connections>
-                            </tableView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="365개의 행복" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LKi-g0-POm">
-                                <rect key="frame" x="24" y="106" width="94" height="20.333333333333329"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" name="customGray"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PBH-Sc-J25" customClass="CapsuleButton" customModule="Happiggy_bank" customModuleProvider="target">
-                                <rect key="frame" x="321" y="100" width="30" height="32"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="tintColor" name="secondaryLabelColor"/>
-                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                                <state key="normal">
-                                    <color key="titleColor" name="secondaryLabelColor"/>
-                                </state>
-                                <connections>
-                                    <action selector="openAllNotesButtonDidTap:" destination="KE3-2Z-kiH" eventType="touchUpInside" id="VxI-Mw-Rpy"/>
-                                </connections>
-                            </button>
+                            </collectionView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="dO5-e2-qa6"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="QYn-0Q-jnc" firstAttribute="top" secondItem="dO5-e2-qa6" secondAttribute="top" constant="56" id="DZZ-fW-GOZ"/>
-                            <constraint firstItem="dO5-e2-qa6" firstAttribute="trailing" secondItem="QYn-0Q-jnc" secondAttribute="trailing" id="KxE-qy-Adj"/>
-                            <constraint firstItem="PBH-Sc-J25" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="LKi-g0-POm" secondAttribute="trailing" priority="250" constant="8" symbolic="YES" id="R8p-Dn-tcz"/>
-                            <constraint firstItem="dO5-e2-qa6" firstAttribute="trailing" secondItem="PBH-Sc-J25" secondAttribute="trailing" constant="24" id="VUS-VU-gQ5"/>
-                            <constraint firstItem="QYn-0Q-jnc" firstAttribute="leading" secondItem="dO5-e2-qa6" secondAttribute="leading" id="Vnt-XQ-Bt4"/>
-                            <constraint firstItem="PBH-Sc-J25" firstAttribute="top" secondItem="dO5-e2-qa6" secondAttribute="top" constant="12" id="WYg-vh-hXn"/>
-                            <constraint firstItem="QYn-0Q-jnc" firstAttribute="top" secondItem="PBH-Sc-J25" secondAttribute="bottom" constant="12" id="Xpb-pp-nT7"/>
-                            <constraint firstItem="LKi-g0-POm" firstAttribute="leading" secondItem="dO5-e2-qa6" secondAttribute="leading" constant="24" id="jwh-PH-Zgf"/>
-                            <constraint firstItem="dO5-e2-qa6" firstAttribute="bottom" secondItem="QYn-0Q-jnc" secondAttribute="bottom" id="nDq-ev-SEG"/>
-                            <constraint firstItem="LKi-g0-POm" firstAttribute="centerY" secondItem="PBH-Sc-J25" secondAttribute="centerY" id="qgW-Jw-Qrc"/>
+                            <constraint firstItem="SCP-Hp-DbX" firstAttribute="leading" secondItem="dO5-e2-qa6" secondAttribute="leading" constant="24" id="7R1-gI-ZZa"/>
+                            <constraint firstItem="dO5-e2-qa6" firstAttribute="trailing" secondItem="SCP-Hp-DbX" secondAttribute="trailing" constant="24" id="HTF-Pb-f7K"/>
+                            <constraint firstItem="SCP-Hp-DbX" firstAttribute="top" secondItem="dO5-e2-qa6" secondAttribute="top" id="Zcu-Yl-d0y"/>
+                            <constraint firstItem="dO5-e2-qa6" firstAttribute="bottom" secondItem="SCP-Hp-DbX" secondAttribute="bottom" id="fYX-ez-D8n"/>
                         </constraints>
                     </view>
                     <toolbarItems/>
                     <navigationItem key="navigationItem" id="6cw-er-3yd"/>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
-                        <outlet property="noteCountLabel" destination="LKi-g0-POm" id="kqy-xQ-oFd"/>
-                        <outlet property="openAllNotesButton" destination="PBH-Sc-J25" id="0GZ-5Z-Sfe"/>
-                        <outlet property="tableView" destination="QYn-0Q-jnc" id="hjF-0v-h7m"/>
+                        <outlet property="collectionView" destination="SCP-Hp-DbX" id="oPG-a7-5GS"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="2zj-Wn-JrU" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -853,9 +834,6 @@
         <image name="xmark" catalog="system" width="128" height="113"/>
         <namedColor name="customGray">
             <color red="0.59999999999999998" green="0.59999999999999998" blue="0.59999999999999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-        <namedColor name="secondaryLabelColor">
-            <color red="0.33333333333333331" green="0.60392156862745094" blue="0.75294117647058822" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="warningLabelColor">
             <color red="1" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Happiggy-bank/Happiggy-bank/Subview/BottleCell.swift
+++ b/Happiggy-bank/Happiggy-bank/Subview/BottleCell.swift
@@ -68,7 +68,6 @@ final class BottleCell: UITableViewCell {
             let note = notes[index]
             let noteContainerView = UIView(frame: self.grid[index] ?? .zero).then {
                 $0.layer.zPosition = Metric.randomZpostion
-                $0.backgroundColor = .note(color: note.color)
             }
             
             let imageView = UIImageView(image: .note(color: note.color)).then {

--- a/Happiggy-bank/Happiggy-bank/Subview/TagCell.swift
+++ b/Happiggy-bank/Happiggy-bank/Subview/TagCell.swift
@@ -1,0 +1,81 @@
+//
+//  TagCell.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/03/25.
+//
+
+import UIKit
+
+/// NoteCollectionView 에서 사용하는 셀
+final class TagCell: UICollectionViewCell {
+    
+    // MARK: - Properties
+    
+    /// 첫 단어 라벨
+    let firstWordLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: Font.firstWordLabel)
+        $0.textAlignment = .center
+    }
+    
+    /// 쪽지 배경 이미지
+    let noteImageView = UIImageView()
+    
+    
+    // MARK: - Inits
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.configureHierarchy()
+        self.configureConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    
+    // MARK: - Functions
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        self.noteImageView.image = UIImage()
+        self.firstWordLabel.text = nil
+        self.contentView.transform = self.transform
+    }
+    
+    /// 뷰 체계 설정
+    private func configureHierarchy() {
+        self.noteImageView.translatesAutoresizingMaskIntoConstraints = false
+        self.firstWordLabel.translatesAutoresizingMaskIntoConstraints = false
+        
+        self.contentView.addSubview(self.noteImageView)
+        self.contentView.addSubview(self.firstWordLabel)
+    }
+    
+    /// 오토레이아웃 설정
+    private func configureConstraints() {
+        self.configureNoteImageViewConstraints()
+        self.configureFirstWordLabelConstraints()
+    }
+    
+    /// 쪽지 이미지뷰 오토레이아웃
+    private func configureNoteImageViewConstraints() {
+        NSLayoutConstraint.activate([
+            self.noteImageView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            self.noteImageView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            self.noteImageView.topAnchor.constraint(equalTo: self.topAnchor),
+            self.noteImageView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+        ])
+    }
+    
+    /// 단어 라벨 오토레이아웃
+    private func configureFirstWordLabelConstraints() {
+        NSLayoutConstraint.activate([
+            self.firstWordLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            self.firstWordLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor)
+        ])
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -291,13 +291,19 @@ extension Bottle {
 
 extension Note {
     
+    /// Note 엔티티에서 사용하는 상수
+    enum Metric {
+        
+        /// 첫 단어 최대 길이로, 이 길이를 초과하면 해당 글자까지 자름
+        static let firstWordMaxLength: Int = 10
+    }
+    
     /// Note 엔티티에서 설정하는 문자열
     enum StringLiteral {
 
         /// 내용 디폴트 값: "?"
         static let content = "?"
     }
-    
 }
 
 extension PersistenceStore {
@@ -541,39 +547,11 @@ extension NoteListViewController {
     /// NoteListViewController 에서 사용하는 상수값
     enum Metric {
         
-        /// 좌우 패딩: 24
-        static let horizontalPadding: CGFloat = 24
+        /// 첫 단어 라벨 위아래 패딩: 16
+        static let firstWordLabelVerticalPadding: CGFloat = 16
         
-        /// 쪽지 이미지 너비
-        static let noteImageWidth = UIScreen.main.bounds.width - 2 * horizontalPadding
-        
-        /// 쪽지 이미지 높이
-        static let noteImageHeight = noteImageWidth * noteImageSizeRatio
-        
-        /// note cell 높이 : 쪽지 이미지 높이 + spacing
-        static let cellHeight = noteImageHeight + noteImageSpacing
-        
-        /// 애니메이션 딜레이 시간: 0.5
-        static let animationDelay: TimeInterval = 0.5
-
-        /// note cell 세로:가로 비율 : 242/327
-        private static let noteImageSizeRatio: CGFloat = 242/327
-        
-        /// 쪽지 이미지 사이 간격: 16
-        private static let noteImageSpacing: CGFloat = 16
-    }
-    
-    /// NoteNoteDatePickerViewModel 에서 사용하는 문자열
-    enum StringLiteral {
-        
-        /// 알림 제목
-        static let alertTitle = "전체 쪽지를 개봉하시겠습니까?"
-        
-        /// 취소 버튼 제목
-        static let cancelButtonTitle = "아니오"
-        
-        /// 확인 버튼 제목
-        static let confirmButtonTitle = "네"
+        /// 첫 단어 라벨 좌우 패딩: 16
+        static let firstWordLabelHorizontalPadding: CGFloat = 16
     }
 }
 
@@ -589,7 +567,7 @@ extension NoteCell {
         static let half: Double = 0.5
         
         /// 좌우 패딩: 25
-        static let horizontalPadding = NoteListViewController.Metric.horizontalPadding
+        static let horizontalPadding: CGFloat = 24
         
         /// 내용 라벨 줄 간격: 8
         static let lineSpacing: CGFloat = 8
@@ -714,5 +692,15 @@ extension CapsuleButton {
         
         /// 외곽선 굵기: 1
         static let borderWidth: CGFloat = 1
+    }
+}
+
+extension TagCell {
+    
+    /// TagCell 폰트
+    enum Font {
+        
+        /// 첫 단어 라벨 폰트 크기: 17
+        static let firstWordLabel: CGFloat = 17
     }
 }

--- a/Happiggy-bank/Happiggy-bank/Utils/TagViewFlowLayout.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/TagViewFlowLayout.swift
@@ -1,0 +1,54 @@
+//
+//  TagViewFlowLayout.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/03/25.
+//
+
+import UIKit
+
+final class TagViewFlowLayout: UICollectionViewFlowLayout {
+    
+    override func prepare() {
+        super.prepare()
+    }
+    
+    override var collectionViewContentSize: CGSize { super.collectionViewContentSize }
+    
+    /// 가운데 정렬 수행
+    override func layoutAttributesForElements(
+        in rect: CGRect
+    ) -> [UICollectionViewLayoutAttributes]? {
+        
+        guard let superAttributes = super.layoutAttributesForElements(in: rect),
+              let attributes = NSArray(array: superAttributes, copyItems: true) as? [UICollectionViewLayoutAttributes]
+
+        else { return nil }
+        
+        let leftMargin = attributes.first?.frame.origin.x ?? self.sectionInset.left
+        
+        /// 각 셀을 순서대로 확인하면서 맨 좌측에 있는 셀은 그대로 두고 그 다음 셀의 시작 위치를 이전 셀의 너비 + spacing 한 값으로 설정
+        for (index, value) in attributes.enumerated() {
+            guard value.frame.origin.x != leftMargin,
+                  index - 1 >= .zero
+            else { continue }
+            
+            let previousCellmaxX = attributes[index - 1].frame.maxX
+            
+            value.frame.origin.x = previousCellmaxX + self.minimumLineSpacing
+        }
+        
+        let contentMaxX: CGFloat = collectionViewContentSize.width - leftMargin
+        let grouped = Dictionary(grouping: attributes, by: { $0.frame.minY })
+        
+        /// 가운데 정렬 작업
+        grouped.values.forEach { attributes in
+            let maxXs = attributes.map { $0.frame.maxX }
+            let diff = (contentMaxX - maxXs.max()!)
+            
+            attributes.forEach { $0.frame.origin.x += diff / 2}
+        }
+        
+        return attributes
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/ViewController/BottleListViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/BottleListViewController.swift
@@ -6,8 +6,8 @@
 //
 
 import UIKit
-
 import CoreData
+
 import Then
 
 /// 유리병 리스트 뷰 컨트롤러
@@ -47,9 +47,9 @@ final class BottleListViewController: UIViewController {
                 let bottle = sender as? Bottle
             else { return }
             
-            let viewModel = NoteListViewModel()
-            viewModel.notes = bottle.notes
-            
+            let viewModel = NoteListViewModel(
+                bottle: bottle, fetchedResultContollerDelegate: noteListViewController
+            )
             noteListViewController.viewModel = viewModel
         }
     }

--- a/Happiggy-bank/Happiggy-bank/ViewController/NoteListViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NoteListViewController.swift
@@ -5,26 +5,20 @@
 //  Created by sun on 2022/03/13.
 //
 
+import CoreData
 import UIKit
 
 /// 개봉한 저금통의 쪽지를 확인할 수 있는 쪽지 리스트(테이블뷰)를 관리하는 뷰 컨트롤러
 final class NoteListViewController: UIViewController {
     
-    // MARK: - IBOutlet
+    // MARK: - @IBOutlets
     
-    /// 쪽지 개수를 나타내는 라벨
-    @IBOutlet weak var noteCountLabel: UILabel!
-    
-    /// 전체 쪽지 개봉 버튼
-    @IBOutlet weak var openAllNotesButton: CapsuleButton!
-    
-    /// 리스트를 나타낼 테이블 뷰
-    @IBOutlet weak var tableView: UITableView!
-    
+    @IBOutlet weak var collectionView: UICollectionView!
+
     
     // MARK: - Properties
     
-    /// 리스트에 나타낼 쪽지 데이터를 담고 있는 뷰모델
+    /// fetched result controller 를 담고 있는 뷰모델
     var viewModel: NoteListViewModel!
     
     
@@ -33,225 +27,105 @@ final class NoteListViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.registerNoteCell()
-        self.configureNavigationBar()
-        self.configureNoteCountLabel()
-        self.configureOpenAllNotesButton()
-        
-        // Uncomment the following line to preserve selection between presentations
-        // self.clearsSelectionOnViewWillAppear = false
-
-        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
-        // self.navigationItem.rightBarButtonItem = self.editButtonItem
+        self.configureCollectionViewLayout()
+        self.collectionView.register(TagCell.self, forCellWithReuseIdentifier: TagCell.name)
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         
-//        PersistenceStore.shared.save()
     }
     
-    // MARK: - @IBActions
-    
-    /// 전체 개봉 버튼을 눌렀을 때 호출되는 메서드
-    @IBAction func openAllNotesButtonDidTap(_ sender: CapsuleButton) {
-        self.showOpenAllNotesConfirmAlert()
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // TODO: DetailView와 연결
     }
     
     
-    // MARK: - Function
+    // MARK: - Functions
     
-    /// 재사용 가능한 note cell 등록
-    private func registerNoteCell() {
-        let nib = UINib(nibName: NoteCell.name, bundle: nil)
-        self.tableView.register(nib, forCellReuseIdentifier: NoteCell.name)
-    }
-    
-    /// 내비게이션 투명화, 제목 설정
-    private func configureNavigationBar() {
-        self.navigationItem.title = self.viewModel.bottleTitle
-        
-        guard let navigationBar = self.navigationController?.navigationBar
-        else { return }
-        
-        navigationBar.setBackgroundImage(UIImage(), for: .default)
-        navigationBar.shadowImage = UIImage()
-    }
-    
-    /// 전체 쪽지 개수 라벨 모습 설정
-    private func configureNoteCountLabel() {
-        self.noteCountLabel.text = self.viewModel.noteCountLabelString
-    }
-    
-    /// 모든 쪽지가 개봉되었으면 숨김 처리
-    private func configureOpenAllNotesButton() {
-        guard self.viewModel.allNotesAreOpen
-        else { return }
-        
-        // TODO: FadeOut 으로 대체할 것
-        UIView.animate(withDuration: 0.2) {
-            self.openAllNotesButton.alpha = .zero
-        } completion: { _ in
-            self.openAllNotesButton.isHidden = true
-        }
-    }
-    
-    /// 쪽지 전체 개봉 의사를 재확인하는 알림을 띄움
-    private func showOpenAllNotesConfirmAlert() {
-        let alert = self.makeConfirmAlert()
-        self.present(alert, animated: true)
-    }
-    
-    /// 쪽지 전체 개봉 의사를 재확인하는 알림 생성
-    private func makeConfirmAlert() -> UIAlertController {
-        let alert = UIAlertController(
-            title: StringLiteral.alertTitle,
-            message: nil,
-            preferredStyle: .alert
-        )
-        
-        let confirmAction = UIAlertAction(
-            title: StringLiteral.confirmButtonTitle,
-            style: .default,
-            handler: { _ in self.openAllNotes() }
-        )
-        
-        let cancelAction = UIAlertAction(
-            title: StringLiteral.cancelButtonTitle,
-            style: .cancel,
-            handler: nil
-        )
-        
-        alert.addAction(confirmAction)
-        alert.addAction(cancelAction)
-        
-        return alert
-    }
-    
-    /// 모든 쪽지를 개봉하는 메서드
-    private func openAllNotes() {
-        
-        let enumeratedUnopenNotes = self.viewModel.enumeratedUnopenNotes
-        let unopenIndexPaths = enumeratedUnopenNotes.map {
-            IndexPath(row: $0.offset, section: .zero)
-        }
-        enumeratedUnopenNotes.forEach { $0.element.isOpen.toggle() }
-        
-        let visibleUnopenRows =  unopenIndexPaths.filter {
-            self.tableView.indexPathsForVisibleRows?.contains($0) == true
-        }
-        self.openNoteWithAnimation(rowsAtIndexPaths: visibleUnopenRows)
-        self.configureOpenAllNotesButton()
-    }
-    
-    /// 현재 화면에 나타나 있는 쪽지를 애니메이션 효과와 함께 개봉하고, completion 으로 데이터 리로드
-    private func openNoteWithAnimation(rowsAtIndexPaths indexPaths: [IndexPath]) {
-
-        let noteCells = indexPaths.compactMap { self.tableView.cellForRow(at: $0) as? NoteCell }
-        
-        /// 차례대로 개봉되는 것처럼 보이도록 딜레이 설정
-        var animationDelay: TimeInterval = .zero
-    
-        for (indexPath, noteCell)  in zip(indexPaths, noteCells) {
-            
-            if noteCell == noteCells.last {
-                noteCell.completion = { _ in self.tableView.reloadData() }
-            }
-            
-            noteCell.animationDelay = animationDelay
-            animationDelay += Metric.animationDelay
-            self.tableView.selectRow(at: indexPath, animated: false, scrollPosition: .none)
-            self.tableView.deselectRow(at: indexPath, animated: false)
-        }
+    /// 컬렉션 뷰의 레이아웃 설정
+    private func configureCollectionViewLayout() {
+        let layout = TagViewFlowLayout()
+        self.collectionView.collectionViewLayout = layout
     }
 }
 
 
-// MARK: - UITableViewDataSource
-
-extension NoteListViewController: UITableViewDataSource {
+// MARK: - UICollectionViewDelegateFlowLayout
+extension NoteListViewController: UICollectionViewDelegateFlowLayout {
     
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        self.viewModel.notes.count
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        sizeForItemAt indexPath: IndexPath
+    ) -> CGSize {
+        
+        let note = self.viewModel.fetchedResultController.object(at: indexPath)
+        
+        let label = UILabel().then {
+            $0.font = .systemFont(ofSize: TagCell.Font.firstWordLabel)
+            $0.text = note.firstWord
+            $0.sizeToFit()
+        }
+        
+        let labelSize = label.frame.size
+        
+        /// 라벨 크기에 여백 추가해서 리턴
+        return CGSize(
+            width: labelSize.width + Metric.firstWordLabelHorizontalPadding,
+            height: labelSize.height + Metric.firstWordLabelVerticalPadding
+        )
+    }
+}
+
+
+// MARK: - UICollectionViewDelegate
+extension NoteListViewController: UICollectionViewDelegate {
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        
+        collectionView.deselectItem(at: indexPath, animated: false)
+        print("link to detail view")
+        // TODO: Detail View 연결
+//        self.performSegue(withIdentifier: "", sender: indexPath)
+    }
+}
+
+
+// MARK: - UICollectionViewDataSource
+extension NoteListViewController: UICollectionViewDataSource {
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        self.viewModel.fetchedResultController.fetchedObjects?.count ?? .zero
     }
     
     // swiftlint:disable force_cast
-    func tableView(
-        _ tableView: UITableView,
-        cellForRowAt indexPath: IndexPath
-    ) -> UITableViewCell {
+    func collectionView(
+        _ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath
+    ) -> UICollectionViewCell {
         
-        let cell = tableView.dequeueReusableCell(
-            withIdentifier: NoteCell.name,
+        let cell = self.collectionView.dequeueReusableCell(
+            withReuseIdentifier: TagCell.name,
             for: indexPath
-        ) as! NoteCell
+        ) as! TagCell
         
-        let note = self.viewModel.notes[indexPath.row]
+        self.configureCell(cell, at: indexPath)
         
-        self.clearCell(cell: cell)
-        self.configureNoteImageView(cell: cell, note: note)
-        self.configureContents(cell: cell, note: note)
-
         return cell
     }
     // swiftlint:enable force_cast
     
-    /// 셀 재사용 시 이전에 설정했던 속성들 리셋
-    private func clearCell(cell: NoteCell) {
-        cell.frontDateLabel.attributedText = nil
-        cell.backDateLabel.attributedText = nil
-        cell.contentLabel.text = nil
-        cell.noteImageView.image = UIImage()
-        cell.animationDelay = .zero
-    }
-    
-    /// 쪽지의 색깔에 맞게 배경/이미지 업데이트
-    private func configureNoteImageView(cell: NoteCell, note: Note) {
-        cell.noteImageView.image = self.viewModel.image(for: note)
-    }
-    
-    /// 쪽지 내용 라벨들 내용 업데이트
-    private func configureContents(cell: NoteCell, note: Note) {
-        /// 내용 입력
-        cell.frontDateLabel.attributedText = self.viewModel.attributedDateString(for: note)
-        cell.backDateLabel.attributedText = self.viewModel.attributedDateString(for: note)
-        cell.contentLabel.text = note.content
+    /// 쪽지 색깔, 첫 번쨰 단어를 사용해서 셀 모습 생성
+    func configureCell(_ cell: TagCell,at indexPath: IndexPath) {
+        let note = self.viewModel.fetchedResultController.object(at: indexPath)
         
-        /// 개봉 여부에 따라 숨김 처리
-        cell.frontDateLabel.isHidden = note.isOpen
-        cell.backDateLabel.isHidden = !note.isOpen
-        cell.contentLabel.isHidden = !note.isOpen
+        // TODO: 첫 단어 추출 메서드 추가
+        cell.firstWordLabel.text = note.firstWord
+        cell.noteImageView.backgroundColor = .note(color: note.color)
     }
 }
 
 
-// MARK: - UITableViewDelegate
-
-extension NoteListViewController: UITableViewDelegate {
-    
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        Metric.cellHeight
-    }
-    
-    func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
-        guard indexPath.row >= .zero,
-              indexPath.row < self.viewModel.numberOfTotalNotes
-        else { return nil }
-        
-        /// 이미 개봉되었으면 다시 누르는 것 방지
-        let note = self.viewModel.notes[indexPath.row]
-        return note.isOpen ? nil : indexPath
-    }
-    
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard indexPath.row >= .zero,
-              indexPath.row < self.viewModel.numberOfTotalNotes
-        else { return }
-
-        let note = self.viewModel.notes[indexPath.row]
-        note.isOpen.toggle()
-        /// 최초 개봉 애니메이션이 스크롤할 떄 마다 다시 나타나는 것 방지
-        tableView.deselectRow(at: indexPath, animated: false)
-        self.configureOpenAllNotesButton()
-    }
-}
+// MARK: - NSFetchedResultsControllerDelegate
+extension NoteListViewController: NSFetchedResultsControllerDelegate { }

--- a/Happiggy-bank/Happiggy-bank/ViewModel/BottleListViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/BottleListViewModel.swift
@@ -39,7 +39,8 @@ final class BottleListViewModel {
         if list.isEmpty {
             /// stock mock data
             list = Bottle.fooOpenBottles
-//            PersistenceStore.shared.save()
+            PersistenceStore.shared.save()
+            print("don't show me")
         }
 //        PersistenceStore.shared.deleteAll(Bottle.self)
         

--- a/Happiggy-bank/Happiggy-bank/ViewModel/NoteListViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/NoteListViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by sun on 2022/03/13.
 //
 
+import CoreData
 import UIKit
 
 /// 쪽지에 필요한 형식으로 데이터를 변환해주는 뷰모델
@@ -12,48 +13,49 @@ final class NoteListViewModel {
     
     // MARK: - Properties
     
-    /// 리스트에서 나타낼 쪽지들의 배열
-    var notes: [Note]!
-    
-    /// 모든 쪽지가 다 개봉되었는지 여부
-    var allNotesAreOpen: Bool {
-        self.notes.first { !$0.isOpen } == nil ? true : false
-    }
-    
-    /// 개봉하지 않은 쪽지들
-    var enumeratedUnopenNotes: [(offset: Int, element: Note)] {
-        self.notes.enumerated().filter { !$1.isOpen }
-    }
-    
-    /// 유리병 제목
-    private(set) lazy var bottleTitle: String = {
-        self.notes.first?.bottle.title ?? StringLiteral.emptyString
-    }()
-    
-    /// 쪽지 전체 개수
-    private(set) lazy var numberOfTotalNotes: Int = {
-        self.notes.count
+    /// 코어데이터로 불러온 쪽지 엔티티들을 관리하는 fetchedResultController
+    lazy var fetchedResultController: NSFetchedResultsController<Note> = {
+        let fetchRequest = Note.fetchRequest(bottle: self.bottle)
+        
+        let context = self.bottle.managedObjectContext ?? PersistenceStore.shared.context
+        
+        let controller = NSFetchedResultsController(
+            fetchRequest: fetchRequest,
+            managedObjectContext: context,
+            sectionNameKeyPath: nil,
+            cacheName: bottle.id.uuidString
+        )
+        
+        controller.delegate = fetchedResultsControllerDelegate
+        
+        do {
+            try controller.performFetch()
+        } catch {
+            fatalError("Failed to fetch entities")
+        }
+        
+        return controller
     }()
     
     /// 쪽지 개수 라벨 문자열
     private(set) lazy var noteCountLabelString: String = {
-        StringLiteral.noteCountLabelString(count: self.numberOfTotalNotes)
+        StringLiteral.noteCountLabelString(
+            count: self.fetchedResultController.fetchedObjects?.count ?? .zero
+        )
     }()
     
+    /// 리스트에서 나타낼 저금통
+    private var bottle: Bottle!
     
-    // MARK: - Functions
+    /// FetchedResultsController 의 델리게이트 역할을 할 컨트롤러 : NoteListController
+    private weak var fetchedResultsControllerDelegate: NSFetchedResultsControllerDelegate?
     
-    /// 날짜를 "2022 02.05" 형태의 문자열로 연도만 볼드 처리해서 변환
-    func attributedDateString(for note: Note) -> NSMutableAttributedString {
-        note.date
-            .customFormatted(type: .spaceAndDot)
-            .nsMutableAttributedStringify()
-            .color(color: .highlight(color: note.color))
-            .bold(targetString: note.date.yearString, fontSize: Font.dateLabelFontSize)
+    
+    // MARK: - Init
+    
+    init(bottle: Bottle, fetchedResultContollerDelegate: NSFetchedResultsControllerDelegate?) {
+        self.bottle = bottle
+        self.fetchedResultsControllerDelegate = fetchedResultContollerDelegate
     }
     
-    /// 색상에 따른 쪽지 이미지 리턴
-    func image(for note: Note) -> UIImage {
-        UIImage(named: StringLiteral.listNote + note.color.capitalizedString) ?? UIImage()
-    }
 }


### PR DESCRIPTION
## 반영 내용
- 이슈 #73 
- 이슈 #72 

<br>

### NoteListViewController 
- 태그들의 모음과 같은 가운데 정렬한 컬렉션 뷰로 변경
  - flowlayout 사용
- 코어데이터 관리를 위해 FetchedResultController 도입
  - 저금통 리스트에서 이제 단순히 저금통만 넘겨받으면 됨
  -  아직 저희가 이동, 삭제 이런 기능은 넣지 않는 것 같아서 델리게이트 메서드들은 구현하지 않았습니다
  - 저금통 리스트에 뷰모델에 있는 거 슥 옮겨가셔서 조금씩만 수정하시면 될 거 같고, 아님 일단 딴 거 부터 하시고 막바지에 가서 제가 옮겨도 될 것 같아요..!
    

<br>

## 추후 작업
- UI 디자인 반영
- 디테일뷰와 연결
- 애니메이션 효과...? 뭐가 좋을까요.. . 
- 삭제 기능은 일단 당장 급한 게 아니라고 생각해서 생략했습니다
