### PR TITLE
[feat] 저금통 뷰 영역, 중력 범위, 쪽지 뷰 충돌 범위 재설정 

### DIFF
--- a/Happiggy-bank/Happiggy-bank/CoreData/Bottle+CoreDataClass.swift
+++ b/Happiggy-bank/Happiggy-bank/CoreData/Bottle+CoreDataClass.swift
@@ -198,7 +198,30 @@ extension Bottle {
         // MARK: - 오늘 이미 작성한 상태 테스트하려면 아래 주석 해제
 //        Note.create(date: Date(), color: NoteColor.yellow, content: "누가 뚝딱 만들어주면 좋겠다 한 3줄 정도까지 채우고 싶은데 아무거나 써보기 이모지도 써보기 시험 시험 테스트 ☀️", bottle: bottle)
         
-        // swiftlint:enable line_length
+        return bottle
+    }()
+    
+    static let fullBottle: Bottle = {
+        var count = 365
+//        count = 180
+//        count = 90
+//        count = 30
+//        count = 7
+        
+        let noteCount = count
+        
+        let startDate = nthDayFromToday(-count)
+        let endDate = nthDayFromToday(-1)
+        
+        let bottle = Bottle(title: "행복냠냠이", startDate: startDate, endDate: endDate)
+        for index in 0..<noteCount {
+            let note = Note.create(
+                date: nthDayFromToday(-index-1),
+                color: NoteColor.allCases.randomElement()!,
+                content: "일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십",
+                bottle: bottle)
+        }
         return bottle
     }()
 }
+// swiftlint:enable line_length

--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -22,27 +22,12 @@
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="homeBackgroundLight" translatesAutoresizingMaskIntoConstraints="NO" id="ZlX-eS-Yvg">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                             </imageView>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="homeBottleBack" translatesAutoresizingMaskIntoConstraints="NO" id="oqE-FC-3Q8">
-                                <rect key="frame" x="0.0" y="249" width="375" height="440"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="oqE-FC-3Q8" secondAttribute="height" multiplier="375:440" id="fo3-oe-RDc"/>
-                                </constraints>
-                            </imageView>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dmA-fx-uIw">
-                                <rect key="frame" x="0.0" y="249" width="375" height="440"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="dmA-fx-uIw" secondAttribute="height" multiplier="375:440" id="W8J-jy-WPj"/>
-                                </constraints>
+                                <rect key="frame" x="0.0" y="44" width="375" height="685"/>
                                 <connections>
                                     <segue destination="FVx-vN-7Xe" kind="embed" identifier="showBottleView" id="rLd-zf-USa"/>
                                 </connections>
                             </containerView>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="homeBottleFront" translatesAutoresizingMaskIntoConstraints="NO" id="0dD-IT-dfb">
-                                <rect key="frame" x="0.0" y="249" width="375" height="440"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="0dD-IT-dfb" secondAttribute="height" multiplier="375:440" id="gcC-qP-AxE"/>
-                                </constraints>
-                            </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Bmu-YM-ARP">
                                 <rect key="frame" x="24" y="100.99999999999999" width="327" height="54.333333333333329"/>
                                 <constraints>
@@ -58,19 +43,14 @@
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="ZlX-eS-Yvg" secondAttribute="bottom" id="0m3-gk-sI3"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="dmA-fx-uIw" secondAttribute="trailing" id="26A-HR-Krh"/>
-                            <constraint firstItem="0dD-IT-dfb" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="5H0-eY-A2Q"/>
                             <constraint firstItem="dmA-fx-uIw" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="8sb-a4-2KC"/>
-                            <constraint firstItem="oqE-FC-3Q8" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="DEf-ts-R9h"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="oqE-FC-3Q8" secondAttribute="bottom" constant="40" id="Hnr-X5-UBq"/>
+                            <constraint firstItem="dmA-fx-uIw" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" constant="44" id="CbZ-gb-u8F"/>
                             <constraint firstItem="ZlX-eS-Yvg" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="OFr-if-N9z"/>
                             <constraint firstAttribute="trailing" secondItem="ZlX-eS-Yvg" secondAttribute="trailing" id="OkY-Ki-cEN"/>
-                            <constraint firstItem="0dD-IT-dfb" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="TmB-xQ-POM"/>
                             <constraint firstItem="Bmu-YM-ARP" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="24" id="dzV-x8-0gt"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="dmA-fx-uIw" secondAttribute="bottom" constant="40" id="eMu-1s-Pwo"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="dmA-fx-uIw" secondAttribute="bottom" id="eMu-1s-Pwo"/>
                             <constraint firstItem="ZlX-eS-Yvg" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="pLj-41-9fI"/>
-                            <constraint firstItem="oqE-FC-3Q8" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="r4l-Un-Gm8"/>
                             <constraint firstItem="Bmu-YM-ARP" firstAttribute="top" secondItem="ZlX-eS-Yvg" secondAttribute="top" constant="101" id="ucC-5M-Fv0"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="0dD-IT-dfb" secondAttribute="bottom" constant="40" id="wuS-UY-k8Y"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Bmu-YM-ARP" secondAttribute="trailing" constant="24" id="x7L-XF-hax"/>
                         </constraints>
                     </view>
@@ -591,30 +571,29 @@
         <scene sceneID="p7l-16-uR7">
             <objects>
                 <viewController modalTransitionStyle="crossDissolve" modalPresentationStyle="fullScreen" id="FVx-vN-7Xe" customClass="BottleViewController" customModule="Happiggy_bank" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="jBg-oD-Piv">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="440"/>
+                    <view key="view" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="jBg-oD-Piv">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="685"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OAt-vo-L69">
-                                <rect key="frame" x="80" y="165" width="215" height="231"/>
+                                <rect key="frame" x="23" y="0.0" width="329" height="685"/>
                                 <gestureRecognizers/>
                                 <connections>
                                     <outletCollection property="gestureRecognizers" destination="gEH-ha-I0H" appends="YES" id="I7T-Ve-Zwh"/>
                                 </connections>
                             </view>
                         </subviews>
-                        <viewLayoutGuide key="safeArea" id="hOc-mc-UUR"/>
+                        <viewLayoutGuide key="safeArea" id="5Hu-eg-CWw"/>
                         <gestureRecognizers/>
                         <constraints>
-                            <constraint firstItem="OAt-vo-L69" firstAttribute="centerX" secondItem="hOc-mc-UUR" secondAttribute="centerX" id="lHD-MC-mZ6"/>
-                            <constraint firstItem="OAt-vo-L69" firstAttribute="height" secondItem="jBg-oD-Piv" secondAttribute="height" multiplier="0.525" id="rHf-uW-8wO"/>
-                            <constraint firstItem="hOc-mc-UUR" firstAttribute="bottom" secondItem="OAt-vo-L69" secondAttribute="bottom" constant="44" id="rUo-wu-z3X"/>
-                            <constraint firstItem="OAt-vo-L69" firstAttribute="width" secondItem="jBg-oD-Piv" secondAttribute="width" multiplier="0.573333" id="saU-qG-RkR"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="OAt-vo-L69" secondAttribute="trailing" constant="7" id="2LI-SU-Shf"/>
+                            <constraint firstItem="OAt-vo-L69" firstAttribute="leading" secondItem="jBg-oD-Piv" secondAttribute="leadingMargin" constant="7" id="KFq-lV-62y"/>
+                            <constraint firstItem="OAt-vo-L69" firstAttribute="top" secondItem="jBg-oD-Piv" secondAttribute="topMargin" id="dBa-F9-eez"/>
+                            <constraint firstAttribute="bottomMargin" secondItem="OAt-vo-L69" secondAttribute="bottom" id="wb2-wb-Iwg"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="bottleNoteView" destination="OAt-vo-L69" id="Xcn-Ec-cu5"/>
-                        <outlet property="bottleNoteViewBottomConstraint" destination="rUo-wu-z3X" id="oDP-fr-ikO"/>
                         <segue destination="moi-e1-3hQ" kind="presentation" identifier="presentNewNoteDatePicker" id="71M-g6-wMS"/>
                         <segue destination="abG-42-vcb" kind="presentation" identifier="presentNewBottleNameField" id="Qcc-qq-Xqy"/>
                         <segue destination="FuI-qc-1fd" kind="presentation" identifier="presentNewNoteTextView" id="xNs-XQ-OjW"/>
@@ -628,7 +607,7 @@
                     </connections>
                 </tapGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="-1154.4000000000001" y="2307.6354679802957"/>
+            <point key="canvasLocation" x="-1154.4000000000001" y="2307.2660098522169"/>
         </scene>
         <!--New Bottle Name Field View Controller-->
         <scene sceneID="BI8-5q-YxJ">
@@ -793,8 +772,8 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="O5Z-N1-x6E"/>
-        <segue reference="7wk-af-F5w"/>
+        <segue reference="xNs-XQ-OjW"/>
+        <segue reference="71M-g6-wMS"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="checkmark" catalog="system" width="128" height="114"/>
@@ -802,8 +781,6 @@
         <image name="chevron.right" catalog="system" width="96" height="128"/>
         <image name="homeBackgroundBlurredLight" width="375" height="812"/>
         <image name="homeBackgroundLight" width="375" height="812"/>
-        <image name="homeBottleBack" width="375" height="440"/>
-        <image name="homeBottleFront" width="375" height="440"/>
         <image name="xmark" catalog="system" width="128" height="113"/>
         <namedColor name="customGray">
             <color red="0.59999999999999998" green="0.59999999999999998" blue="0.59999999999999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -583,7 +583,6 @@
                                 </connections>
                             </view>
                         </subviews>
-                        <viewLayoutGuide key="safeArea" id="5Hu-eg-CWw"/>
                         <gestureRecognizers/>
                         <constraints>
                             <constraint firstAttribute="trailingMargin" secondItem="OAt-vo-L69" secondAttribute="trailing" constant="7" id="2LI-SU-Shf"/>

--- a/Happiggy-bank/Happiggy-bank/Subview/NoteView.swift
+++ b/Happiggy-bank/Happiggy-bank/Subview/NoteView.swift
@@ -12,59 +12,43 @@ import Then
 /// 저금통에 담길 노트 노드
 final class NoteView: UIView {
     
-    // MARK: Properties
+    // MARK: - Properties
+        
+    override var collisionBoundsType: UIDynamicItemCollisionBoundsType {
+        .ellipse
+    }
     
     /// 노트 노드 이미지
-    var imageView: UIImageView = UIImageView().then {
-        $0.image = UIImage.note(color: .default)
-        $0.translatesAutoresizingMaskIntoConstraints = false
+    private var imageView: UIImageView!
+    
+    
+    // MARK: - Inits
+    
+    private override init(frame: CGRect) {
+        super.init(frame: frame)
     }
     
-    /// 노트 노드 레이어
-    var shapeLayer: CAShapeLayer = {
-        let shapeLayer = CAShapeLayer()
-        shapeLayer.fillColor = UIColor.clear.cgColor
-        shapeLayer.allowsEdgeAntialiasing = true
-        return shapeLayer
-    }()
-    
-    override var collisionBoundsType: UIDynamicItemCollisionBoundsType {
-        return .path
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
     }
-
-    override var collisionBoundingPath: UIBezierPath {
-        return circularPath()
-    }
-
     
-    // MARK: Override Functions
-    
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        self.addSubview(self.imageView)
-
-        layer.addSublayer(shapeLayer)
-        let center = CGPoint(x: bounds.midX, y: bounds.midY)
-        shapeLayer.path = circularPath(lineWidth: 0, center: center).cgPath
-    }
-
-    
-    // MARK: Functions
-    
-    // TODO: 이미지에 맞게 path 설정
-    /// 원형 path 설정
-    private func circularPath(
-        lineWidth: CGFloat = 0,
-        center: CGPoint = .zero
-    ) -> UIBezierPath {
-        let radius = (min(bounds.width, bounds.height) - lineWidth) / 2
+    convenience init(frame: CGRect, color: NoteColor) {
+        self.init(frame: frame)
         
-        return UIBezierPath(
-            arcCenter: center,
-            radius: radius,
-            startAngle: 0,
-            endAngle: .pi * 2,
-            clockwise: true
-        )
+        self.layer.zPosition = Metric.randomZpostion
+        self.configureImageView(withColor: color)
+    }
+    
+    
+    // MARK: - Functions
+    
+    /// 쪽지 색깔에 맞게 이미지 뷰를 생성하고 서브 뷰로 추가
+    private func configureImageView(withColor color: NoteColor) {
+        self.imageView = UIImageView(image: .note(color: color)).then {
+            $0.frame = self.bounds
+            $0.contentMode = .scaleAspectFit
+            $0.transform = self.transform.rotated(by: Metric.randomDegree)
+        }
+        self.addSubview(self.imageView)
     }
 }

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -38,48 +38,9 @@ extension BottleViewController {
     /// BottleViewController 에서 설정하는 layout 에 적용할 상수값들을 모아놓은 enum
     enum Metric {
         
-        /// TODO: 모든 뷰에서 같으면 전역으로 만들기
-        /// 좌우 패딩 값
-        static let verticalPadding: CGFloat = HomeViewController.Metric.verticalPadding
+        /// 현재 뷰를 기준으로 충돌 영역 설정을 위해 넣을 상하좌우 마진
+        static let collisionBoundaryInsets = UIEdgeInsets(top: .zero, left: 3, bottom: 3, right: 3)
         
-        /// 저금통 안에 들어갈 쪽지 노드 너비
-        static let noteWidth: CGFloat = 12
-        
-        /// 저금통 안에 들어갈 쪽지 노드 높이
-        static let noteHeight: CGFloat = noteWidth
-        
-        /// Gravity에 추가될 x축 패딩
-        static let boundaryPosX: CGFloat = 5
-        
-        /// Gravity에 추가될 y축 패딩
-        static let boundaryPosY: CGFloat = 5
-        
-        /// Gravity에 추가될 수평 패딩
-        static let boundaryPadding: CGFloat = 10
-        
-        /// 쪽지 이미지들의 z index
-        static var randomZpostion: CGFloat {
-            [3, 4, 5, 6, 7, 8].randomElement() ?? 3
-        }
-        
-        /// 쪽지 이미지 scale
-        static var randomScale: CGFloat {
-            [1, 1.1, 1.2, 1.3, 1.4, 1.5].randomElement() ?? .one
-        }
-        
-        /// 쪽지 이미지 회전 각도
-        static var randomDegree: CGFloat {
-            2 * .pi / (degreeDividers.randomElement() ?? .one)
-        }
-        
-        /// 쪽지 이미지들의 회전 각도를 구하기 위한 값들
-        private static let degreeDividers: [CGFloat] = {
-            var degree = [CGFloat]()
-            for number in 1...36 {
-                degree.append(CGFloat(number))
-            }
-            return degree
-        }()
     }
 }
 
@@ -739,5 +700,38 @@ extension SettingsViewCell {
         
         /// 좌우 패딩: 24
         static let HorizontalPadding: CGFloat = 24
+    }
+}
+
+
+extension NoteView {
+    
+    /// NoteView 에서 사용하는 상수값
+    enum Metric {
+        
+        /// 쪽지 이미지들의 z index
+        static var randomZpostion: CGFloat {
+            [3, 4, 5, 6, 7, 8].randomElement() ?? 3
+        }
+        
+        // TODO: 삭제
+        /// 쪽지 이미지 scale
+        static var randomScale: CGFloat {
+            [1, 1.1, 1.2, 1.3, 1.4, 1.5].randomElement() ?? .one
+        }
+        
+        /// 쪽지 이미지 회전 각도
+        static var randomDegree: CGFloat {
+            2 * .pi / (degreeDividers.randomElement() ?? .one)
+        }
+        
+        /// 쪽지 이미지들의 회전 각도를 구하기 위한 값들
+        private static let degreeDividers: [CGFloat] = {
+            var degree = [CGFloat]()
+            for number in 1...36 {
+                degree.append(CGFloat(number))
+            }
+            return degree
+        }()
     }
 }

--- a/Happiggy-bank/Happiggy-bank/Utils/Gravity.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Gravity.swift
@@ -15,14 +15,18 @@ public class Gravity: NSObject {
 
     private var dynamicItems: [UIDynamicItem]
     private var collisionItems: [UIDynamicItem]
-    private var boundaryPath: UIBezierPath
-
+    
+    /// reference view 를 기준으로 설정할 충돌 영역의 상하좌우 마진
+    private var collisionBoundaryInsets: UIEdgeInsets
+    
     /// Initialize the components
-    public init( gravityItems: [UIDynamicItem],
-                 collisionItems: [UIDynamicItem]?,
-                 referenceView: UIView,
-                 boundary: UIBezierPath,
-                 queue: OperationQueue? ) {
+    public init(
+        gravityItems: [UIDynamicItem],
+        collisionItems: [UIDynamicItem]?,
+        referenceView: UIView,
+        collisionBoundaryInsets: UIEdgeInsets,
+        queue: OperationQueue?
+    ) {
         self.dynamicItems = gravityItems
 
         if let collisionItems = collisionItems {
@@ -30,17 +34,16 @@ public class Gravity: NSObject {
         } else {
             self.collisionItems = self.dynamicItems
         }
-
-        self.boundaryPath = boundary
         
         if let queue = queue {
             self.queue = queue
         } else {
             self.queue = OperationQueue.current ?? OperationQueue.main
         }
-
+        
         animator = UIDynamicAnimator(referenceView: referenceView)
         gravity = UIGravityBehavior(items: self.dynamicItems)
+        self.collisionBoundaryInsets = collisionBoundaryInsets
     }
     
     /// Enable motion and behaviors
@@ -67,10 +70,7 @@ public class Gravity: NSObject {
 
     private func collisionBehavior() -> UICollisionBehavior {
         let collision = UICollisionBehavior(items: self.collisionItems)
-        collision.addBoundary(
-            withIdentifier: "borders" as NSCopying,
-            for: self.boundaryPath
-        )
+        collision.setTranslatesReferenceBoundsIntoBoundary(with: self.collisionBoundaryInsets)
         return collision
     }
 

--- a/Happiggy-bank/Happiggy-bank/ViewController/BottleViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/BottleViewController.swift
@@ -50,6 +50,18 @@ final class BottleViewController: UIViewController {
         initializeBottleView()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        self.gravity?.enable()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        self.gravity?.disable()
+    }
+    
     
     // MARK: - @IBActions
     
@@ -156,7 +168,7 @@ final class BottleViewController: UIViewController {
         else { return }
         
         self.fillBottleNoteView(forBottle: bottle)
-        self.activateGravity()
+        self.addGravity()
     }
     
     /// BottleNoteView 에 쪽지 이미지들을 추가
@@ -169,35 +181,22 @@ final class BottleViewController: UIViewController {
     
     /// 그리드를 사용해서 bottleNoteView 의 해당 좌표에 NoteView 추가
     private func addNoteView(_ note: Note, at index: Int) {
-        let noteView = NoteView(frame: self.grid[index] ?? .zero).then {
-            /// 겹쳐보이는 효과
-            $0.layer.zPosition = Metric.randomZpostion
-            $0.imageView = UIImageView(image: .note(color: note.color))
-            $0.imageView.transform = $0.transform.rotated(by: Metric.randomDegree)
-        }
+        let noteView = NoteView(frame: self.grid[index] ?? .zero, color: note.color)
         self.bottleNoteView.addSubview(noteView)
     }
     
     /// 쪽지 이미지들에 중력 효과 추가
     /// 유저가 폰을 기울이는 방향으로 쪽지들이 떨어짐
-    private func activateGravity() {
+    private func addGravity() {
         self.noteNodes = self.bottleNoteView.subviews.filter { $0 is NoteView }
-
+                
         gravity = Gravity(
             gravityItems: self.noteNodes,
             collisionItems: nil,
-            referenceView: self.bottleNoteView,
-            boundary: UIBezierPath(rect: CGRect(
-                x: Metric.boundaryPosX,
-                y: Metric.boundaryPosY,
-                width: self.bottleNoteView.bounds.width - Metric.boundaryPadding,
-                height: self.bottleNoteView.bounds.height - Metric.boundaryPadding
-            )),
+            referenceView: self.view,
+            collisionBoundaryInsets: Metric.collisionBoundaryInsets,
             queue: nil
         )
-        
-        // start gravity
-        gravity?.enable()
     }
     
     

--- a/Happiggy-bank/Happiggy-bank/ViewModel/HomeViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/HomeViewModel.swift
@@ -54,6 +54,7 @@ final class HomeViewModel {
 //
 //        self.bottle = bottles.first
         
-        self.bottle = Bottle.foo
+//        self.bottle = Bottle.foo
+        self.bottle = Bottle.fullBottle
     }
 }


### PR DESCRIPTION
## 작업내용
- 이슈 #82 

<br>

- 디자인 변경에 따라 홈뷰에서 저금통 영역을 화면 전체를 차지하도록 재설정
- 저금통 뷰 그리드 범위도 쪽지가 자연스럽게 펼쳐지는 범위에서 최대로 지정
- 중력 영역 설정을 뷰 바운드를 그대로 사용하기 위해 바운더리 설정 방식 변경
- 쪽지 이미지가 겹치는 정도를 줄이고, 테트리스 모양 아니고 자연스럽게 쌓이도록 collision path type 을 ellipse (원형)으로 변경
- cpu 사용량을 줄이기 위해서 뷰가 나타날때 gravity 를 적용하고, 사라질 때는 멈춤
 
<br>

## 추후 작업
- 중력 정도 조정
- 쪽지 이미지 해상도 변경 필요