### PR TITLE
[feat] 쪽지 디테일 캐러셀 뷰 구현

### DIFF
--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A41DE62427F34ABB002A7669 /* UPCarouselFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A41DE62327F34ABB002A7669 /* UPCarouselFlowLayout.swift */; };
+		A41DE62627F36595002A7669 /* NoteDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A41DE62527F36595002A7669 /* NoteDetailViewController.swift */; };
+		A41DE62827F368BF002A7669 /* NoteDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A41DE62727F368BF002A7669 /* NoteDetailViewModel.swift */; };
+		A41DE62B27F36E95002A7669 /* NoteCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A41DE62927F36E95002A7669 /* NoteCell.swift */; };
+		A41DE62C27F36E95002A7669 /* NoteCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = A41DE62A27F36E95002A7669 /* NoteCell.xib */; };
 		A425F8B627EDF4FB00A005AB /* TagViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A425F8B527EDF4FB00A005AB /* TagViewFlowLayout.swift */; };
 		A425F8B827EDF59A00A005AB /* TagCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A425F8B727EDF59A00A005AB /* TagCell.swift */; };
 		A439F53A27EEFC28002851F4 /* SettingsViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A439F53927EEFC27002851F4 /* SettingsViewCell.swift */; };
@@ -27,8 +32,6 @@
 		A48E183E27E737B600B44477 /* CapsuleButton.xib in Resources */ = {isa = PBXBuildFile; fileRef = A48E183D27E737B600B44477 /* CapsuleButton.xib */; };
 		A490AC4E27DD945E00B04CE1 /* NoteListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A490AC4D27DD945E00B04CE1 /* NoteListViewController.swift */; };
 		A490AC5027DD9D2E00B04CE1 /* NoteListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A490AC4F27DD9D2E00B04CE1 /* NoteListViewModel.swift */; };
-		A490AC5527DDA0CA00B04CE1 /* NoteCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A490AC5327DDA0CA00B04CE1 /* NoteCell.swift */; };
-		A490AC5627DDA0CA00B04CE1 /* NoteCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = A490AC5427DDA0CA00B04CE1 /* NoteCell.xib */; };
 		A491018527D6EDE90012DFDD /* PersistenceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A491018427D6EDE90012DFDD /* PersistenceStore.swift */; };
 		A491018727D6F37C0012DFDD /* NSObject+Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = A491018627D6F37C0012DFDD /* NSObject+Name.swift */; };
 		A491018D27D7358B0012DFDD /* Bottle+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = A491018C27D7358B0012DFDD /* Bottle+CoreDataClass.swift */; };
@@ -87,6 +90,11 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		A41DE62327F34ABB002A7669 /* UPCarouselFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UPCarouselFlowLayout.swift; sourceTree = "<group>"; };
+		A41DE62527F36595002A7669 /* NoteDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDetailViewController.swift; sourceTree = "<group>"; };
+		A41DE62727F368BF002A7669 /* NoteDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDetailViewModel.swift; sourceTree = "<group>"; };
+		A41DE62927F36E95002A7669 /* NoteCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteCell.swift; sourceTree = "<group>"; };
+		A41DE62A27F36E95002A7669 /* NoteCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NoteCell.xib; sourceTree = "<group>"; };
 		A425F8B527EDF4FB00A005AB /* TagViewFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagViewFlowLayout.swift; sourceTree = "<group>"; };
 		A425F8B727EDF59A00A005AB /* TagCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagCell.swift; sourceTree = "<group>"; };
 		A439F53927EEFC27002851F4 /* SettingsViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewCell.swift; sourceTree = "<group>"; };
@@ -106,8 +114,6 @@
 		A48E183D27E737B600B44477 /* CapsuleButton.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CapsuleButton.xib; sourceTree = "<group>"; };
 		A490AC4D27DD945E00B04CE1 /* NoteListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteListViewController.swift; sourceTree = "<group>"; };
 		A490AC4F27DD9D2E00B04CE1 /* NoteListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteListViewModel.swift; sourceTree = "<group>"; };
-		A490AC5327DDA0CA00B04CE1 /* NoteCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteCell.swift; sourceTree = "<group>"; };
-		A490AC5427DDA0CA00B04CE1 /* NoteCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NoteCell.xib; sourceTree = "<group>"; };
 		A491018427D6EDE90012DFDD /* PersistenceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceStore.swift; sourceTree = "<group>"; };
 		A491018627D6F37C0012DFDD /* NSObject+Name.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Name.swift"; sourceTree = "<group>"; };
 		A491018C27D7358B0012DFDD /* Bottle+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bottle+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -198,6 +204,7 @@
 				A490AC4F27DD9D2E00B04CE1 /* NoteListViewModel.swift */,
 				A8ECD4A627E33BFA00886BC0 /* BottleListViewModel.swift */,
 				A4C1AFD127E5C60E0096CD3E /* NewNoteTextViewModel.swift */,
+				A41DE62727F368BF002A7669 /* NoteDetailViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -233,12 +240,12 @@
 			isa = PBXGroup;
 			children = (
 				A89CBEDA27CBDD99005549F6 /* BottleCell.swift */,
-				A490AC5327DDA0CA00B04CE1 /* NoteCell.swift */,
 				D2C48C0027E9DFA1006FC59E /* NoteView.swift */,
 				A425F8B727EDF59A00A005AB /* TagCell.swift */,
 				A439F53927EEFC27002851F4 /* SettingsViewCell.swift */,
 				A439F53B27EEFCF6002851F4 /* SettingsToggleButtonCell.swift */,
 				A439F54327EF0698002851F4 /* SettingsLabelButtonCell.swift */,
+				A41DE62927F36E95002A7669 /* NoteCell.swift */,
 			);
 			path = Subview;
 			sourceTree = "<group>";
@@ -263,8 +270,9 @@
 				A89CBEDC27CBDEA2005549F6 /* BottleListViewController.swift */,
 				A4B2860427D9A546008769EB /* NewNoteDatePickerViewController.swift */,
 				A4B2860827D9A56A008769EB /* NewNoteTextViewController.swift */,
-				A490AC4D27DD945E00B04CE1 /* NoteListViewController.swift */,
 				A459003727E8D107003010A0 /* SettingsViewController.swift */,
+				A490AC4D27DD945E00B04CE1 /* NoteListViewController.swift */,
+				A41DE62527F36595002A7669 /* NoteDetailViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -277,6 +285,7 @@
 				D2C48BFE27E9D60A006FC59E /* Gravity.swift */,
 				A459003927E95D6B003010A0 /* Grid.swift */,
 				A425F8B527EDF4FB00A005AB /* TagViewFlowLayout.swift */,
+				A41DE62327F34ABB002A7669 /* UPCarouselFlowLayout.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -284,12 +293,12 @@
 		A8BD834527BE332100E0DE41 /* Storyboard */ = {
 			isa = PBXGroup;
 			children = (
-				A490AC5427DDA0CA00B04CE1 /* NoteCell.xib */,
 				A4F5715127DB715100E7DF9B /* ColorButton.xib */,
 				A8FC07CD27B3ECF00077A758 /* Main.storyboard */,
 				A467B5C927DA289500AC702D /* NewNoteDatePickerRowView.xib */,
 				A8FC07D227B3ECF30077A758 /* LaunchScreen.storyboard */,
 				A8ECD4A427E30FF300886BC0 /* BottleCell.xib */,
+				A41DE62A27F36E95002A7669 /* NoteCell.xib */,
 				A48E183D27E737B600B44477 /* CapsuleButton.xib */,
 				A439F53C27EEFCF6002851F4 /* SettingsToggleButtonCell.xib */,
 				A439F54427EF0698002851F4 /* SettingsLabelButtonCell.xib */,
@@ -448,7 +457,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A490AC5627DDA0CA00B04CE1 /* NoteCell.xib in Resources */,
 				A8ECD4A527E30FF300886BC0 /* BottleCell.xib in Resources */,
 				A8FC07DD27B3EF030077A758 /* .swiftlint.yml in Resources */,
 				A467B5CA27DA289600AC702D /* NewNoteDatePickerRowView.xib in Resources */,
@@ -456,6 +464,7 @@
 				A48E183E27E737B600B44477 /* CapsuleButton.xib in Resources */,
 				A439F54627EF0698002851F4 /* SettingsLabelButtonCell.xib in Resources */,
 				A439F53E27EEFCF6002851F4 /* SettingsToggleButtonCell.xib in Resources */,
+				A41DE62C27F36E95002A7669 /* NoteCell.xib in Resources */,
 				A8FC07D127B3ECF30077A758 /* Assets.xcassets in Resources */,
 				A8FC07CF27B3ECF00077A758 /* Main.storyboard in Resources */,
 				A4F5715227DB715100E7DF9B /* ColorButton.xib in Resources */,
@@ -492,6 +501,7 @@
 				A425F8B827EDF59A00A005AB /* TagCell.swift in Sources */,
 				A4B2860F27D9F539008769EB /* NewNoteDatePickerViewModel.swift in Sources */,
 				A467B5C827DA258700AC702D /* NewNoteDatePickerRowView.swift in Sources */,
+				A41DE62B27F36E95002A7669 /* NoteCell.swift in Sources */,
 				A4C1AFD227E5C60E0096CD3E /* NewNoteTextViewModel.swift in Sources */,
 				A819CFA127DE034F00DE8E72 /* NewBottle.swift in Sources */,
 				A456657C27CC66FD007CF70A /* DefaultButton.swift in Sources */,
@@ -550,7 +560,9 @@
 				A4C1AFC227E47AD80096CD3E /* String+EmptyString.swift in Sources */,
 				A4C1AFC627E482E10096CD3E /* CGFloat+Values.swift in Sources */,
 				A8BD833F27BE30B400E0DE41 /* Constants.swift in Sources */,
-				A490AC5527DDA0CA00B04CE1 /* NoteCell.swift in Sources */,
+				A41DE62827F368BF002A7669 /* NoteDetailViewModel.swift in Sources */,
+				A41DE62627F36595002A7669 /* NoteDetailViewController.swift in Sources */,
+				A41DE62427F34ABB002A7669 /* UPCarouselFlowLayout.swift in Sources */,
 				A4F5714727DA467900E7DF9B /* DateFormat.swift in Sources */,
 				A89CBEDD27CBDEA2005549F6 /* BottleListViewController.swift in Sources */,
 				A439F53A27EEFC28002851F4 /* SettingsViewCell.swift in Sources */,

--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		A41DE62827F368BF002A7669 /* NoteDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A41DE62727F368BF002A7669 /* NoteDetailViewModel.swift */; };
 		A41DE62B27F36E95002A7669 /* NoteCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A41DE62927F36E95002A7669 /* NoteCell.swift */; };
 		A41DE62C27F36E95002A7669 /* NoteCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = A41DE62A27F36E95002A7669 /* NoteCell.xib */; };
+		A41DE62E27F5F2C1002A7669 /* UIView+ZoomAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A41DE62D27F5F2C1002A7669 /* UIView+ZoomAnimation.swift */; };
 		A425F8B627EDF4FB00A005AB /* TagViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A425F8B527EDF4FB00A005AB /* TagViewFlowLayout.swift */; };
 		A425F8B827EDF59A00A005AB /* TagCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A425F8B727EDF59A00A005AB /* TagCell.swift */; };
 		A439F53A27EEFC28002851F4 /* SettingsViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A439F53927EEFC27002851F4 /* SettingsViewCell.swift */; };
@@ -95,6 +96,7 @@
 		A41DE62727F368BF002A7669 /* NoteDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDetailViewModel.swift; sourceTree = "<group>"; };
 		A41DE62927F36E95002A7669 /* NoteCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteCell.swift; sourceTree = "<group>"; };
 		A41DE62A27F36E95002A7669 /* NoteCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NoteCell.xib; sourceTree = "<group>"; };
+		A41DE62D27F5F2C1002A7669 /* UIView+ZoomAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+ZoomAnimation.swift"; sourceTree = "<group>"; };
 		A425F8B527EDF4FB00A005AB /* TagViewFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagViewFlowLayout.swift; sourceTree = "<group>"; };
 		A425F8B727EDF59A00A005AB /* TagCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagCell.swift; sourceTree = "<group>"; };
 		A439F53927EEFC27002851F4 /* SettingsViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewCell.swift; sourceTree = "<group>"; };
@@ -338,6 +340,7 @@
 				A4C1AFD327E5E6120096CD3E /* UITextView+ParagraphStyle.swift */,
 				A459003B27E9C5C9003010A0 /* CGSize+Area.swift */,
 				A48E183927E71D9300B44477 /* UILabel+ParagraphStyle.swift */,
+				A41DE62D27F5F2C1002A7669 /* UIView+ZoomAnimation.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -537,6 +540,7 @@
 				A4B2860527D9A546008769EB /* NewNoteDatePickerViewController.swift in Sources */,
 				A491018527D6EDE90012DFDD /* PersistenceStore.swift in Sources */,
 				A491018D27D7358B0012DFDD /* Bottle+CoreDataClass.swift in Sources */,
+				A41DE62E27F5F2C1002A7669 /* UIView+ZoomAnimation.swift in Sources */,
 				A439F54527EF0698002851F4 /* SettingsLabelButtonCell.swift in Sources */,
 				A490AC5027DD9D2E00B04CE1 /* NoteListViewModel.swift in Sources */,
 				A4F5714927DA589100E7DF9B /* NoteDatePickerData.swift in Sources */,

--- a/Happiggy-bank/Happiggy-bank/CoreData/Bottle+CoreDataClass.swift
+++ b/Happiggy-bank/Happiggy-bank/CoreData/Bottle+CoreDataClass.swift
@@ -165,8 +165,7 @@ extension Bottle {
             Note.create(
                 date: nthDayFromToday(index),
                 color: NoteColor.allCases.randomElement()!,
-                content:
-                    "일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십",
+                content: randomContent,
                 bottle: bottle
             )
         }
@@ -225,10 +224,73 @@ extension Bottle {
             let note = Note.create(
                 date: nthDayFromToday(-index-1),
                 color: NoteColor.allCases.randomElement()!,
-                content: "일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십",
+                content: randomContent,
                 bottle: bottle)
         }
         return bottle
     }()
+
+
+    static var randomContent: String {
+        let content = rawData
+        .components(separatedBy: NSCharacterSet.whitespacesAndNewlines)
+        .shuffled()
+        .joined(separator: " ")
+        .prefix(100)
+        
+        return String(content)
+        
+    }
 }
+
+// swiftlint:disable private_over_fileprivate
+fileprivate let rawData = """
+       \n\n   발맞춰 어디론가 run away
+    (Yeah) 건조한 사막이라도 okay
+    (Yeah) 구름은 햇빛의 우산이 돼\n
+    Oh I'm not alone
+    하루하루 눈을 뜨고 나면 새로움 투성이
+    거울 속에 나는 나를 만나
+    새로운나를꽃피워
+    시간은 단지 그리면 돼 (그리면 돼)
+    정해진 건 하나 없는 (Yeah, yeah)
+    늦거나 빠른 건 없어
+    우리 인생은 la-la-la-la-la-la
+    평행선을 넘어 꿈의 노를 저어보자
+    행복의 시간은 마음속 주머니에 가득 차
+    서두르지 마 늘 충분하니까 그대로 있어도 돼
+    나의 여행의 시작은 나야
+    저 태양 위로 my my my my my way
+    한 걸음마다 가까이 가까이 oh-ooh-oh
+    내가 바라던 곳이야
+    흔들리지 않게 맘을 잡아
+    나에게로 oh-oh-oh-oh 가까이 my my way
+    BRRRR BAA
+    두 손 가득히 쥔 모든 것을
+    BRRRR BAA
+    날 위해 내버려도 괜찮아
+    Hey 어딘가로 더 가까이 Hey (어디로 가?)
+    아직은 undecided hey hey
+    아무도 정해주지 못해
+    나만이 La-la-la-la-la-la
+    바다 위를 날아 꿈의 날개 펼쳐보자
+    행복의 무게는 아무도 정하지 못하니까
+    서두르지마 늘 충분하니까 그대로 있어도 돼
+    나의 여행의 시작은 나야
+    저 태양 위로 my my my my my way
+    한 걸음마다 가까이 가까이 oh-ooh-oh
+    내가 바라던 곳이야
+    흔들리지않게맘을잡아
+    나에게로 oh-oh-oh-oh 가까이 my my way
+    내 삶은 여행 여행 여행
+    내 맘을 걷네 걷네
+    이 길은 나의 road movie
+    내 길은 오랜 노래 노래
+    저 태양 위로 my my my my my way (ah!)
+    한 걸음마다 가까이 가까이
+    내가 바라던 곳이야
+    흔들리지 않게 맘을 잡아
+    나에게로 oh-oh-oh-oh 가까이 my my way
+    """
 // swiftlint:enable line_length
+// swiftlint:enable private_over_fileprivate

--- a/Happiggy-bank/Happiggy-bank/Extensions/UIView+ZoomAnimation.swift
+++ b/Happiggy-bank/Happiggy-bank/Extensions/UIView+ZoomAnimation.swift
@@ -1,0 +1,97 @@
+//
+//  UIView+ZoomAnimation.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/03/31.
+//
+
+import UIKit
+
+extension UIView {
+    
+    // MARK: - Enums
+    
+    /// 줌 애니메이션 관련 상수값
+    private enum ZoomAnimation {
+        
+        /// 축소(줌 아웃) 스케일: 0.9
+        static let transformDownScale: CGFloat = 0.9
+        
+        /// 확대(줌 인) 스케일: 1.1
+        static let transformUpScale: CGFloat = 1.1
+        
+        /// 축소 효과(1.0 -> 0.9) 시작: 1/4
+        static let scaleDownRelativeStart: Double = .zero
+
+        /// 축소 효과(1.0 -> 0.9) 시간: 0
+        static let scaleDownRelativeDuration: Double = 1/4
+
+        /// 확대 효과(0.9 -> 1.1) 시작: 1/4
+        static let scaleUpRelativeStart: Double = scaleDownRelativeDuration
+
+        /// 확대 효과(0.9 -> 1.1) 시간: 2/4
+        static let scaleUpRelativeDuration: Double = 2/4
+
+        /// 원래 사이즈로 돌아가는 효과(1.1-> 1.0)의 시작: 3/4
+        static let identityRelativeStart: Double = scaleUpRelativeStart + scaleUpRelativeDuration
+
+        /// 원래 사이즈로 돌아가는 효과(1.1-> 1.0)의 시간: 1/4
+        static let identityRelativeDuration: Double = 1/4
+    }
+    
+    
+    // MARK: - Functions
+    
+    /// 뷰를 줌(축소->확대->원래 크기)하는 애니메이션 효과
+    func zoomAnimation(
+        duration: Double,
+        delay: Double = .zero,
+        options: UIView.KeyframeAnimationOptions = [],
+        completion: ((Bool) -> Void)? = nil,
+        downScale: Double = ZoomAnimation.transformDownScale,
+        upScale: Double = ZoomAnimation.transformUpScale
+    ) {
+        UIView.animateKeyframes(
+            withDuration: duration,
+            delay: delay,
+            options: options
+        ) {
+            self.addZoomAnimationKeyFrame(
+                scale: downScale,
+                relativeStartTime: ZoomAnimation.scaleDownRelativeStart,
+                relativeDuration: ZoomAnimation.scaleDownRelativeDuration
+            )
+            self.addZoomAnimationKeyFrame(
+                scale: upScale,
+                relativeStartTime: ZoomAnimation.scaleUpRelativeStart,
+                relativeDuration: ZoomAnimation.scaleUpRelativeDuration
+            )
+            UIView.addKeyframe(
+                withRelativeStartTime: ZoomAnimation.identityRelativeStart,
+                relativeDuration: ZoomAnimation.identityRelativeDuration
+            ) {
+                self.transform = .identity
+            }
+            
+        } completion: { result in
+            guard let completion = completion
+            else { return }
+            
+            completion(result)
+        }
+    }
+    
+    /// 줌 애니메이션 생성을 위한 syntatic sugar
+    private func addZoomAnimationKeyFrame(
+        scale: CGFloat,
+        relativeStartTime: Double,
+        relativeDuration: Double
+    ) {
+        UIView.addKeyframe(
+            withRelativeStartTime: relativeStartTime,
+            relativeDuration: relativeDuration
+        ) {
+            self.transform = CGAffineTransform(scaleX: scale, y: scale)
+        }
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -109,17 +109,17 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="SCP-Hp-DbX">
-                                <rect key="frame" x="24" y="88" width="342" height="673"/>
+                                <rect key="frame" x="0.0" y="88" width="390" height="673"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="22E-Nu-lTg">
+                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="22E-Nu-lTg" customClass="TagViewFlowLayout" customModule="Happiggy_bank" customModuleProvider="target">
                                     <size key="itemSize" width="128" height="128"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                    <inset key="sectionInset" minX="24" minY="0.0" maxX="24" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="cell" id="CtU-HV-3BA">
-                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                        <rect key="frame" x="24" y="0.0" width="128" height="128"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="mMj-FT-KQ4">
                                             <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
@@ -136,8 +136,8 @@
                         <viewLayoutGuide key="safeArea" id="dO5-e2-qa6"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="SCP-Hp-DbX" firstAttribute="leading" secondItem="dO5-e2-qa6" secondAttribute="leading" constant="24" id="7R1-gI-ZZa"/>
-                            <constraint firstItem="dO5-e2-qa6" firstAttribute="trailing" secondItem="SCP-Hp-DbX" secondAttribute="trailing" constant="24" id="HTF-Pb-f7K"/>
+                            <constraint firstItem="SCP-Hp-DbX" firstAttribute="leading" secondItem="dO5-e2-qa6" secondAttribute="leading" id="7R1-gI-ZZa"/>
+                            <constraint firstItem="dO5-e2-qa6" firstAttribute="trailing" secondItem="SCP-Hp-DbX" secondAttribute="trailing" id="HTF-Pb-f7K"/>
                             <constraint firstItem="SCP-Hp-DbX" firstAttribute="top" secondItem="dO5-e2-qa6" secondAttribute="top" id="Zcu-Yl-d0y"/>
                             <constraint firstItem="dO5-e2-qa6" firstAttribute="bottom" secondItem="SCP-Hp-DbX" secondAttribute="bottom" id="fYX-ez-D8n"/>
                         </constraints>

--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -147,6 +147,7 @@
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="collectionView" destination="SCP-Hp-DbX" id="oPG-a7-5GS"/>
+                        <segue destination="8AM-Vb-C6f" kind="show" identifier="showNoteDetailView" id="W2u-aU-5bk"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="2zj-Wn-JrU" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -585,6 +586,7 @@
                                 </connections>
                             </view>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="Car-X3-Th6"/>
                         <gestureRecognizers/>
                         <constraints>
                             <constraint firstAttribute="trailingMargin" secondItem="OAt-vo-L69" secondAttribute="trailing" constant="7" id="2LI-SU-Shf"/>
@@ -703,6 +705,48 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="8DE-rs-fK7" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-330.39999999999998" y="3036.9458128078818"/>
+        </scene>
+        <!--Note Detail View Controller-->
+        <scene sceneID="bNV-s0-R6J">
+            <objects>
+                <viewController id="8AM-Vb-C6f" customClass="NoteDetailViewController" customModule="Happiggy_bank" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="XRY-6G-qf4">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="YA1-XK-Qra">
+                                <rect key="frame" x="0.0" y="88" width="390" height="624"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" id="xTl-3o-fVa" customClass="UPCarouselFlowLayout" customModule="Happiggy_bank" customModuleProvider="target">
+                                    <size key="itemSize" width="270" height="400"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells/>
+                                <connections>
+                                    <outlet property="dataSource" destination="8AM-Vb-C6f" id="fje-sJ-FVy"/>
+                                    <outlet property="delegate" destination="8AM-Vb-C6f" id="b5c-Gv-BWr"/>
+                                </connections>
+                            </collectionView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="QbK-9a-8Hy"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="QbK-9a-8Hy" firstAttribute="trailing" secondItem="YA1-XK-Qra" secondAttribute="trailing" id="3Sg-7Y-lal"/>
+                            <constraint firstItem="YA1-XK-Qra" firstAttribute="leading" secondItem="QbK-9a-8Hy" secondAttribute="leading" id="jIO-6J-8kR"/>
+                            <constraint firstItem="QbK-9a-8Hy" firstAttribute="bottom" secondItem="YA1-XK-Qra" secondAttribute="bottom" id="jsd-cb-fbV"/>
+                            <constraint firstItem="YA1-XK-Qra" firstAttribute="top" secondItem="QbK-9a-8Hy" secondAttribute="top" id="n9s-Lh-4MM"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="Oof-lh-Pm3"/>
+                    <connections>
+                        <outlet property="collectionView" destination="YA1-XK-Qra" id="BSi-aG-HY3"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="vmB-E0-XWB" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="891" y="3184"/>
         </scene>
         <!--New Bottle Date Picker View Controller-->
         <scene sceneID="JKs-7X-Gkc">

--- a/Happiggy-bank/Happiggy-bank/Storyboard/NoteCell.xib
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/NoteCell.xib
@@ -4,64 +4,53 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="NoteCell" rowHeight="256" id="KGk-i7-Jjw" customClass="NoteCell" customModule="Happiggy_bank" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="327" height="242"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="327" height="242"/>
-                <autoresizingMask key="autoresizingMask"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" reuseIdentifier="NoteCell" id="gTV-IL-0wX" customClass="NoteCell" customModule="Happiggy_bank" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="188" height="338"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                <rect key="frame" x="0.0" y="0.0" width="188" height="338"/>
+                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
-                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="cL4-kp-d58">
-                        <rect key="frame" x="0.0" y="0.0" width="327" height="226"/>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="RcI-Nk-MJp">
+                        <rect key="frame" x="0.0" y="0.0" width="188" height="338"/>
                     </imageView>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wbq-Tz-IcI">
-                        <rect key="frame" x="143" y="103" width="41.5" height="20.5"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" insetsLayoutMarginsFromSafeArea="NO" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5H8-XD-cFS">
+                        <rect key="frame" x="16" y="90" width="159" height="21.5"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="18"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gz4-u7-xg9">
-                        <rect key="frame" x="16" y="16" width="41.5" height="20.5"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsLetterSpacingToFitWidth="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="97k-pG-TgR">
-                        <rect key="frame" x="16" y="44.5" width="295" height="23"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="19"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" insetsLayoutMarginsFromSafeArea="NO" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cOY-rW-RKA">
+                        <rect key="frame" x="16" y="32" width="37.5" height="18"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>
-                <constraints>
-                    <constraint firstItem="wbq-Tz-IcI" firstAttribute="centerX" secondItem="cL4-kp-d58" secondAttribute="centerX" id="GnB-is-11l"/>
-                    <constraint firstItem="97k-pG-TgR" firstAttribute="trailing" secondItem="cL4-kp-d58" secondAttribute="trailing" constant="-16" id="Kz8-yY-XdN"/>
-                    <constraint firstAttribute="trailing" secondItem="cL4-kp-d58" secondAttribute="trailing" id="P3d-aG-y6K"/>
-                    <constraint firstItem="97k-pG-TgR" firstAttribute="leading" secondItem="gz4-u7-xg9" secondAttribute="leading" id="QIA-g9-QDv"/>
-                    <constraint firstAttribute="bottom" secondItem="cL4-kp-d58" secondAttribute="bottom" constant="16" id="R6a-40-KyS"/>
-                    <constraint firstItem="gz4-u7-xg9" firstAttribute="leading" secondItem="cL4-kp-d58" secondAttribute="leading" constant="16" id="b2R-Rb-JSL"/>
-                    <constraint firstItem="cL4-kp-d58" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="bN2-YG-06e"/>
-                    <constraint firstItem="97k-pG-TgR" firstAttribute="top" secondItem="gz4-u7-xg9" secondAttribute="bottom" constant="8" id="dKc-r8-Kve"/>
-                    <constraint firstItem="wbq-Tz-IcI" firstAttribute="centerY" secondItem="cL4-kp-d58" secondAttribute="centerY" id="qua-zL-hP1"/>
-                    <constraint firstItem="gz4-u7-xg9" firstAttribute="top" secondItem="cL4-kp-d58" secondAttribute="top" constant="16" id="rhV-hr-tOW"/>
-                    <constraint firstItem="cL4-kp-d58" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="tye-y5-iSc"/>
-                </constraints>
-            </tableViewCellContentView>
-            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            </view>
+            <constraints>
+                <constraint firstItem="RcI-Nk-MJp" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="5Ko-Mi-MUa"/>
+                <constraint firstAttribute="bottom" secondItem="RcI-Nk-MJp" secondAttribute="bottom" id="7Go-5F-cND"/>
+                <constraint firstAttribute="trailing" secondItem="RcI-Nk-MJp" secondAttribute="trailing" id="Fsl-YJ-3ZD"/>
+                <constraint firstItem="5H8-XD-cFS" firstAttribute="trailing" secondItem="RcI-Nk-MJp" secondAttribute="trailing" constant="-13" id="MPD-ao-7Ei"/>
+                <constraint firstItem="5H8-XD-cFS" firstAttribute="leading" secondItem="cOY-rW-RKA" secondAttribute="leading" id="NtP-Kd-3Cn"/>
+                <constraint firstItem="cOY-rW-RKA" firstAttribute="leading" secondItem="RcI-Nk-MJp" secondAttribute="leading" constant="16" id="Yif-mp-OJ5"/>
+                <constraint firstItem="5H8-XD-cFS" firstAttribute="top" secondItem="cOY-rW-RKA" secondAttribute="bottom" constant="40" id="doh-id-8wM"/>
+                <constraint firstItem="cOY-rW-RKA" firstAttribute="top" secondItem="RcI-Nk-MJp" secondAttribute="top" constant="32" id="mMS-Zr-5S3"/>
+                <constraint firstItem="RcI-Nk-MJp" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="yAv-Ad-3qy"/>
+            </constraints>
+            <size key="customSize" width="188" height="338"/>
             <connections>
-                <outlet property="backDateLabel" destination="gz4-u7-xg9" id="iBM-v9-r9m"/>
-                <outlet property="contentLabel" destination="97k-pG-TgR" id="AON-tl-kY3"/>
-                <outlet property="frontDateLabel" destination="wbq-Tz-IcI" id="RuD-Ow-0fr"/>
-                <outlet property="imageView" destination="cL4-kp-d58" id="eDp-fM-acV"/>
-                <outlet property="noteImageView" destination="cL4-kp-d58" id="fSX-yA-GZw"/>
+                <outlet property="contentLabel" destination="5H8-XD-cFS" id="Tng-0U-UqO"/>
+                <outlet property="dateLabel" destination="cOY-rW-RKA" id="Yll-VN-Fd7"/>
+                <outlet property="noteImageView" destination="RcI-Nk-MJp" id="X3T-xP-cZl"/>
             </connections>
-            <point key="canvasLocation" x="-8" y="123"/>
-        </tableViewCell>
+            <point key="canvasLocation" x="140.57971014492756" y="97.767857142857139"/>
+        </collectionViewCell>
     </objects>
 </document>

--- a/Happiggy-bank/Happiggy-bank/Subview/NoteCell.swift
+++ b/Happiggy-bank/Happiggy-bank/Subview/NoteCell.swift
@@ -2,103 +2,49 @@
 //  NoteCell.swift
 //  Happiggy-bank
 //
-//  Created by sun on 2022/03/13.
+//  Created by sun on 2022/03/30.
 //
 
 import UIKit
 
-/// 쪽지 리스트에서 사용할 셀
-final class NoteCell: UITableViewCell {
+/// 쪽지 디테일 뷰에서 사용하는 쪽지 셀
+final class NoteCell: UICollectionViewCell {
     
-    // MARK: - @IBOulet
+    // MARK: - @IBOutlet
     
-    /// 색깔에 따라 쪽지 이미지 혹은 배경색을 변경할 뷰
-    @IBOutlet var noteImageView: UIImageView!
+    /// 쪽지 작성 날짜 라벨
+    @IBOutlet weak var dateLabel: UILabel!
     
-    /// 앞면(미개봉) 날짜 라벨
-    @IBOutlet weak var frontDateLabel: UILabel!
+    /// 쪽지 내용 라벨
+    @IBOutlet weak var contentLabel: UILabel!
     
-    /// 뒷면(개봉) 날짜 라벨
-    @IBOutlet weak var backDateLabel: UILabel!
-    
-    /// 뒷면에 나타날 쪽지 내용
-    @IBOutlet weak var contentLabel: UILabel! {
-        didSet {
-            self.contentLabel.configureParagraphStyle(
-                lineSpacing: Metric.lineSpacing,
-                characterSpacing: Metric.characterSpacing
-            )
-        }
-    }
-    
-    /// 애니메이션 딜레이 시간: 디폴트 0
-    var animationDelay: TimeInterval = .zero
-    
-    /// 애니메이션 후 실행할 작업
-    var completion: ((Bool) -> Void)?
+    /// 쪽지 배경 이미지
+    @IBOutlet weak var noteImageView: UIImageView!
     
     
-    // MARK: - Function
+    // MARK: - Override Functions
     
     override func awakeFromNib() {
         super.awakeFromNib()
+        
+        self.configureContentLabel()
     }
     
-    override func layoutSubviews() {
-        super.layoutSubviews()
+    override func prepareForReuse() {
+        self.noteImageView.image = UIImage()
+        self.dateLabel.text = nil
+        self.contentLabel.text = nil
         
-        self.contentView.frame = self.contentView.frame.inset(
-            by: UIEdgeInsets(
-                top: .zero,
-                left: Metric.horizontalPadding,
-                bottom: .zero,
-                right: Metric.horizontalPadding
-            )
+    }
+    
+    
+    // MARK: - Functions
+    
+    /// 내용 라벨 자간, 행간 설정
+    private func configureContentLabel() {
+        self.contentLabel.configureParagraphStyle(
+            lineSpacing: Metric.lineSpacing,
+            characterSpacing: Metric.characterSpacing
         )
-    }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-        
-        guard selected
-        else { return }
-        
-        self.updateLabelStates()
-        self.animateLabelStateUpdates()
-    }
-    
-    /// (선택된 경우에 호출하는 메서드로) 내용 라벨과 뒷면 날짜 라벨을 나타내고, 앞면 날짜 라벨을 숨김 처리
-    private func updateLabelStates() {
-        self.frontDateLabel.isHidden = true
-        self.contentLabel.isHidden = false
-        self.backDateLabel.isHidden = false
-    }
-    
-    /// (선택된 경우에 호출하는 메서드로) 날짜 라벨이 이동하면 내용 라벨이 페이드인하는 효과를 나타냄
-    private func animateLabelStateUpdates() {
-        /// 페이드 인 효과를 위해 투명도 0으로 설정
-        self.contentLabel.alpha = .zero
-        /// 이동 효과 주기 위해 프레임을 가운데로 변경
-        self.backDateLabel.frame = self.frontDateLabel.frame
-
-        UIView.animateKeyframes(
-            withDuration: Metric.animationDuration,
-            delay: self.animationDelay
-        ) {
-            /// 날짜 라벨 이동 애니메이션
-            UIView.addKeyframe(withRelativeStartTime: .zero, relativeDuration: Metric.half) {
-                self.layoutIfNeeded()
-            }
-            /// 내용 라벨 페이드 인 애니메이션
-            UIView.addKeyframe(withRelativeStartTime: Metric.half, relativeDuration: Metric.half) {
-                self.contentLabel.alpha = .one
-            }
-        } completion: { result in
-            guard let completion = self.completion else {
-                return
-            }
-            
-            completion(result)
-        }
     }
 }

--- a/Happiggy-bank/Happiggy-bank/Subview/TagCell.swift
+++ b/Happiggy-bank/Happiggy-bank/Subview/TagCell.swift
@@ -43,7 +43,7 @@ final class TagCell: UICollectionViewCell {
         
         self.noteImageView.image = UIImage()
         self.firstWordLabel.text = nil
-        self.contentView.transform = self.transform
+        self.transform = .identity
     }
     
     /// 뷰 체계 설정

--- a/Happiggy-bank/Happiggy-bank/Subview/TagCell.swift
+++ b/Happiggy-bank/Happiggy-bank/Subview/TagCell.swift
@@ -36,7 +36,7 @@ final class TagCell: UICollectionViewCell {
     }
     
     
-    // MARK: - Functions
+    // MARK: - Override Functions
     
     override func prepareForReuse() {
         super.prepareForReuse()
@@ -46,6 +46,8 @@ final class TagCell: UICollectionViewCell {
         self.transform = .identity
     }
     
+    
+    // MARK: - Functions 
     /// 뷰 체계 설정
     private func configureHierarchy() {
         self.noteImageView.translatesAutoresizingMaskIntoConstraints = false

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -317,6 +317,9 @@ enum SegueIdentifier {
     
     /// 쪽지 작성뷰 컨트롤러에서 저장 버튼을 눌러서 보틀뷰 컨트롤러로 돌아갈 때 사용
     static let unwindToBottleViewFromNoteTextViewBySave = "unwindToBottleViewFromNoteTextViewFromSaveButton"
+    
+    /// 쪽지 리스트 컨트롤러에서 쪽지 디테일 뷰 컨트롤러를 띄울 때 사용
+    static let showNoteDetailView = "showNoteDetailView"
 }
 
 extension CATransition {
@@ -524,15 +527,6 @@ extension NoteCell {
     /// NoteCell 에서 사용하는 상수들
     enum Metric {
         
-        /// 애니메이션 지속 시간: 0.6
-        static let animationDuration: TimeInterval = 0.6
-        
-        /// 50%
-        static let half: Double = 0.5
-        
-        /// 좌우 패딩: 25
-        static let horizontalPadding: CGFloat = 24
-        
         /// 내용 라벨 줄 간격: 8
         static let lineSpacing: CGFloat = 8
         
@@ -624,22 +618,8 @@ extension NewNoteDatePickerViewModel {
 
 extension NoteListViewModel {
     
-    /// NoteListViewModel 에서 지정하는 폰트 크기
-    enum Font {
-        
-        /// 날짜라벨 폰트 크기: 17
-        static let dateLabelFontSize: CGFloat = 17
-        
-    }
-    
     /// NoteListViewModel 에서 사용하는 문자열
     enum StringLiteral {
-        
-        /// 빈 문자열: 저금통 제목을 불러올 수 없을 때 사용
-        static let emptyString = ""
-        
-        /// 쪽지 이미지 에셋 호출을 위해 앞에 붙일 접두사
-        static let listNote: String = "listNote"
         
         /// 쪽지 개수 라벨에서 개수 뒤에 붙일 문자열: 리턴 "행복 n개"
         static func noteCountLabelString(count: Int) -> String { "행복 \(count)개" }
@@ -752,5 +732,32 @@ extension Gravity {
         
         /// 디바이스 모션 업데이트 주기: 0.5
         static let deviceMotionUpdateInterval: CGFloat = 0.5
+    }
+}
+
+extension NoteDetailViewModel {
+    
+    /// 폰트 관련 설정
+    enum Font {
+        
+        /// 날짜라벨 폰트 크기: 15
+        static let dateLabelFontSize: CGFloat = 15
+    }
+    
+    /// 문자열
+    enum StringLiteral {
+        
+        /// 쪽지 이미지 에셋 호출을 위해 앞에 붙일 접두사
+        static let listNote: String = "listNote"
+    }
+}
+
+extension NoteDetailViewController {
+    
+    /// 상수값
+    enum Metric {
+        
+        /// 양 옆에 보일 아이템의 너비: 30
+        static let sideItemVisibleWidth: CGFloat = 30
     }
 }

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -520,20 +520,22 @@ extension NoteListViewController {
         /// 첫 단어 라벨 좌우 패딩: 16
         static let firstWordLabelHorizontalPadding: CGFloat = 16
         
-        /// 축소 스케일: 0.9
-        static let transformDownScale: CGFloat = 0.9
+        /// 2
+        static let two = 2.0
         
-        /// 확대 스케일: 1.1
-        static let transformUpScale: CGFloat = 1.1
+    }
+    
+    /// 줌 애니메이션
+    enum ZoomAnimation {
         
-        /// 셀 줌 효과 시간: 0.3
-        static let cellZoomAnimationDuration: CGFloat = 0.3
+        /// 화면이 최초로 나타날 때 줌 효과 시간: 0.5
+        static let initialDisplayDuration: CGFloat = 0.5
         
-        /// 확대 효과(0.9 -> 1.1) 상대적 시간: 2/3
-        static let upScaleRelativeDuration: CGFloat = 2/3
-
-        /// 축소 효과(1.1 -> 1.0) 상대적 시간: 1/3
-        static let downScaleRelativeDuration: CGFloat = 1/3
+        /// 순차적 효과를 위한 딜레이: 0.1
+        static let initialDisplayDelayBase: TimeInterval = 0.1
+        
+        /// 셀 선택 시 줌 효과 시간: 0.3
+        static let selectionDuration: Double = 0.3
     }
 }
 

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -519,6 +519,21 @@ extension NoteListViewController {
         
         /// 첫 단어 라벨 좌우 패딩: 16
         static let firstWordLabelHorizontalPadding: CGFloat = 16
+        
+        /// 축소 스케일: 0.9
+        static let transformDownScale: CGFloat = 0.9
+        
+        /// 확대 스케일: 1.1
+        static let transformUpScale: CGFloat = 1.1
+        
+        /// 셀 줌 효과 시간: 0.3
+        static let cellZoomAnimationDuration: CGFloat = 0.3
+        
+        /// 확대 효과(0.9 -> 1.1) 상대적 시간: 2/3
+        static let upScaleRelativeDuration: CGFloat = 2/3
+
+        /// 축소 효과(1.1 -> 1.0) 상대적 시간: 1/3
+        static let downScaleRelativeDuration: CGFloat = 1/3
     }
 }
 

--- a/Happiggy-bank/Happiggy-bank/Utils/UPCarouselFlowLayout.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/UPCarouselFlowLayout.swift
@@ -1,0 +1,200 @@
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2016 Paul Ulric
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+//  UPCarouselFlowLayout.swift
+//  UPCarouselFlowLayoutDemo
+//
+//  Created by Paul Ulric on 23/06/2016.
+//  Copyright © 2016 Paul Ulric. All rights reserved.
+//
+
+import UIKit
+
+/// 캐러셀 뷰에서 아이템 간 간격 설정 방식
+public enum UPCarouselFlowLayoutSpacingMode {
+    /// 아이템 간 고정 거리
+    case fixed(spacing: CGFloat)
+    /// 양옆 아이템이 보일 정도를 설정
+    case overlap(visibleOffset: CGFloat)
+}
+
+/// 캐러셀 뷰를 구현하기 위한 컬렉션 플로우 레이아웃
+final class UPCarouselFlowLayout: UICollectionViewFlowLayout {
+    
+    /// 레이아웃 상태
+    fileprivate struct LayoutState {
+        var size: CGSize
+        func isEqual(_ otherState: LayoutState) -> Bool {
+            return self.size.equalTo(otherState.size)
+        }
+    }
+    
+    /// 양 옆 아이템:중앙 아이템 크기
+    @IBInspectable public var sideItemScale: CGFloat = 0.6
+    
+    /// 양 옆 아이템:중앙 아이템 불투명도
+    @IBInspectable public var sideItemAlpha: CGFloat = 0.6
+    
+    /// 양 옆 아이템의 x축 오프셋
+    @IBInspectable public var sideItemShift: CGFloat = .zero
+    
+    /// 아이템 간 간격 설정 방식
+    public var spacingMode = UPCarouselFlowLayoutSpacingMode.fixed(spacing: 40)
+    
+    fileprivate var state = LayoutState(size: .zero)
+    
+    
+    override public func prepare() {
+        super.prepare()
+        let currentState = LayoutState(size: self.collectionView!.bounds.size)
+        
+        guard !self.state.isEqual(currentState)
+        else { return }
+        
+        self.setupCollectionView()
+        self.updateLayout()
+        self.state = currentState
+    }
+    
+    /// scroll deceleration 속도 설정
+    fileprivate func setupCollectionView() {
+        guard let collectionView = self.collectionView,
+              collectionView.decelerationRate != .fast
+        else { return }
+        
+        collectionView.decelerationRate = .fast
+    }
+    
+    /// 섹션 크기를 아이템 사이즈로 조정
+    fileprivate func updateLayout() {
+        guard let collectionView = self.collectionView else { return }
+        
+        let collectionSize = collectionView.bounds.size
+        
+        let yInset = (collectionSize.height - self.itemSize.height) / 2
+        let xInset = (collectionSize.width - self.itemSize.width) / 2
+        self.sectionInset = UIEdgeInsets.init(
+            top: yInset,
+            left: xInset,
+            bottom: yInset,
+            right: xInset
+        )
+        
+        
+        let sideWidth = self.itemSize.width
+        
+        /// 좌우에 약간 보일 아이템들과 중앙에 있는 아이템들 사이의 간격
+        let scaledItemOffset =  sideWidth * (1 - self.sideItemScale) / 2
+        
+        switch self.spacingMode {
+        /// 고정 거리
+        case .fixed(let spacing):
+            self.minimumLineSpacing = spacing - scaledItemOffset
+        /// 아이템일 보일 정도
+        case .overlap(let visibleWidth):
+            /// 중앙 아이템의 각 끝에서 컬렉션 뷰의 leading/trailing 까지의 거리
+            let inset = xInset
+            /// 아이템을 축소하면서 scaledItemOffset 만큼 더 떨어져 있는 것 처럼 보이기 때문에 visibleWidth 만큼 보이게 하려면
+            /// 현재 스페이싱인 xInset 에서 해당 간격만큼을 빼줘야 함
+            let fullSizeSideItemOverlap = visibleWidth + scaledItemOffset
+            self.minimumLineSpacing = inset - fullSizeSideItemOverlap
+        }
+    }
+    
+    override public func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
+        /// 유저가 스크롤할 때마다 레이아웃을 업데이트 해야 하므로 true
+        true
+    }
+    
+    override public func layoutAttributesForElements(
+        in rect: CGRect
+    ) -> [UICollectionViewLayoutAttributes]? {
+        guard let superAttributes = super.layoutAttributesForElements(in: rect),
+              let attributes = NSArray(
+                array: superAttributes,
+                copyItems: true
+              ) as? [UICollectionViewLayoutAttributes]
+            else { return nil }
+        
+        return attributes.map { self.transformLayoutAttributes($0) }
+    }
+    
+    ///
+    fileprivate func transformLayoutAttributes(
+        _ attributes: UICollectionViewLayoutAttributes
+    ) -> UICollectionViewLayoutAttributes {
+        
+        guard let collectionView = self.collectionView
+        else { return attributes }
+        
+        let collectionViewCenter = collectionView.frame.size.width / 2
+        let offset = collectionView.contentOffset.x
+        let normalizedCenter = attributes.center.x - offset
+        
+        /// 두 아이템 사이의 고정 간격
+        let maxDistance = self.itemSize.width + self.minimumLineSpacing
+        /// 컬렉션 뷰의 중앙과 아이템의 중앙 사이의 간격
+        let distance = min(abs(collectionViewCenter - normalizedCenter), maxDistance)
+        
+        /// 컬렉션 뷰 중앙에 오면 1이 되고, 멀어지면 0이 됨
+        /// 거리를 기준으로 투명도, 크기를 조정하기 위한 값
+        let ratio = (maxDistance - distance) / maxDistance
+        
+        let alpha = ratio * (1 - self.sideItemAlpha) + self.sideItemAlpha
+        let scale = ratio * (1 - self.sideItemScale) + self.sideItemScale
+        let shift = (1 - ratio) * self.sideItemShift
+        
+        attributes.alpha = alpha
+        attributes.transform3D = CATransform3DScale(CATransform3DIdentity, scale, scale, 1)
+        attributes.zIndex = Int(alpha * 10)
+        attributes.center.y = (attributes.center.y + shift)
+        
+        return attributes
+    }
+    
+    /// 스크롤 시 항상 하나의 아이템으로 snap 하도록 오프셋 조정
+    override public func targetContentOffset(
+        forProposedContentOffset proposedContentOffset: CGPoint,
+        withScrollingVelocity velocity: CGPoint
+    ) -> CGPoint {
+        guard let collectionView = collectionView,
+              !collectionView.isPagingEnabled,
+              let layoutAttributes = self.layoutAttributesForElements(in: collectionView.bounds)
+        else { return super.targetContentOffset(forProposedContentOffset: proposedContentOffset) }
+
+        let halfOfCenterWidth = collectionView.bounds.size.width / 2
+        let proposedContentOffsetCenterOriginX = proposedContentOffset.x + halfOfCenterWidth
+
+        /// 스크롤이 끝나서 업데이트 된 중앙 지점과 가장 가까운 레이아웃 어트리뷰트
+        let closest = layoutAttributes.sorted {
+            abs($0.center.x - proposedContentOffsetCenterOriginX) <
+                abs($1.center.x - proposedContentOffsetCenterOriginX)
+        }.first ?? UICollectionViewLayoutAttributes()
+
+        /// 가장 가까운 아이템을 기준으로 스크롤할 새로운 지점의 origin 설정
+        let adjustedTargetContentOffset = CGPoint(
+            x: floor(closest.center.x - halfOfCenterWidth), y: proposedContentOffset.y
+        )
+        
+        return adjustedTargetContentOffset
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/ViewController/NoteDetailViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NoteDetailViewController.swift
@@ -1,0 +1,136 @@
+//
+//  NoteDetailViewController.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/03/30.
+//
+
+import UIKit
+
+/// 쪽지 디테일 뷰 컨트롤러로 캐러셀 뷰 구현을 위해 컬렉션 뷰 사용
+final class NoteDetailViewController: UIViewController {
+    
+    // MARK: - @IBOutlets
+    
+    /// 캐러셀 뷰를 나타낼 컬렉션 뷰
+    @IBOutlet weak var collectionView: UICollectionView!
+    
+    
+    // MARK: - Properties
+    
+    var viewModel: NoteDetailViewModel!
+    
+    // TODO: 디자인 픽스 후 불필요하면 삭제
+    /// 현재 쪽지 페이지의 크기
+    private var pageSize: CGSize {
+        guard let layout = self.collectionView.collectionViewLayout as? UPCarouselFlowLayout
+        else { return .zero }
+        
+        var pageSize = layout.itemSize
+        pageSize.width += layout.minimumLineSpacing
+        
+        return pageSize
+    }
+
+    
+    // MARK: - Life cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        self.configureCollectionViewLayout()
+        self.registerCell()
+        
+    }
+    
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+        
+        self.scrollToInitialPage()
+    }
+    
+    
+    // MARK: - Functions
+    
+    /// 컬렉션 뷰 레이아웃 초기 설정
+    private func configureCollectionViewLayout() {
+        guard let layout = self.collectionView.collectionViewLayout as? UPCarouselFlowLayout
+        else { return }
+        
+        // TODO: 디자인 픽스 후 중앙 셀 크기, 좌우 셀 크기, 투명도 수정
+        layout.spacingMode = .overlap(visibleOffset: Metric.sideItemVisibleWidth)
+    }
+    
+    /// 유저가 선택해서 넘어온 쪽지 페이지로 이동
+    private func scrollToInitialPage() {
+        guard self.viewModel.selectedIndex != .zero,
+              self.collectionView.contentSize != .zero
+        else { return }
+        
+        let indexPath = IndexPath(item: self.viewModel.selectedIndex, section: .zero)
+        self.collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: false)
+    }
+    
+    /// 셀 등록
+    private func registerCell() {
+        let nib = UINib(nibName: NoteCell.name, bundle: nil)
+        self.collectionView.register(nib, forCellWithReuseIdentifier: NoteCell.name)
+    }
+}
+
+
+// MARK: - UICollectionViewDataSource
+extension NoteDetailViewController: UICollectionViewDataSource {
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        numberOfItemsInSection section: Int
+    ) -> Int {
+        self.viewModel.notes.count
+    }
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath
+    ) -> UICollectionViewCell {
+        
+        guard let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: NoteCell.name,
+            for: indexPath
+        ) as? NoteCell
+        else { return NoteCell() }
+        
+        let note = self.viewModel.notes[indexPath.row]
+        
+        self.configureNoteCell(cell, note: note)
+        return cell
+    }
+    
+    /// 쪽지 셀 구성
+    private func configureNoteCell(_ cell: NoteCell, note: Note) {
+        cell.noteImageView.image = self.viewModel.image(for: note)
+        cell.dateLabel.attributedText = self.viewModel.attributedDateString(for: note)
+        cell.contentLabel.text = note.content
+    }
+}
+
+
+// MARK: - UIScrollViewDelegate
+extension NoteDetailViewController: UIScrollViewDelegate {
+    
+    // TODO: 디자인 확인 후 필요 없으면 삭제
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        let pageWidth = self.pageSize.width
+        let offset = scrollView.contentOffset.x
+
+        self.viewModel.selectedIndex = Int(floor((offset - pageWidth / 2) / pageWidth) + 1)
+    }
+}
+
+
+// MARK: - UICollectionViewDelegate
+extension NoteDetailViewController: UICollectionViewDelegate { }
+
+
+// MARK: - UICollectionViewDelegateFlowLayout
+extension NoteDetailViewController: UICollectionViewDelegateFlowLayout { }

--- a/Happiggy-bank/Happiggy-bank/ViewController/NoteListViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NoteListViewController.swift
@@ -27,7 +27,6 @@ final class NoteListViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.configureCollectionViewLayout()
         self.collectionView.register(TagCell.self, forCellWithReuseIdentifier: TagCell.name)
         self.configureNavigationBar()
     }
@@ -47,12 +46,6 @@ final class NoteListViewController: UIViewController {
     
     
     // MARK: - Functions
-    
-    /// 컬렉션 뷰의 레이아웃 설정
-    private func configureCollectionViewLayout() {
-        let layout = TagViewFlowLayout()
-        self.collectionView.collectionViewLayout = layout
-    }
     
     /// 네비게이션 바 초기 설정
     private func configureNavigationBar() {

--- a/Happiggy-bank/Happiggy-bank/ViewController/NoteListViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NoteListViewController.swift
@@ -29,15 +29,20 @@ final class NoteListViewController: UIViewController {
         
         self.configureCollectionViewLayout()
         self.collectionView.register(TagCell.self, forCellWithReuseIdentifier: TagCell.name)
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
+        self.configureNavigationBar()
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // TODO: DetailView와 연결
+        
+        if segue.identifier == SegueIdentifier.showNoteDetailView {
+            guard let noteDetailViewController = segue.destination as? NoteDetailViewController,
+                  let notes = self.viewModel.fetchedResultController.fetchedObjects,
+                  let selectedIndex = sender as? Int
+            else { return }
+            
+            let viewModel = NoteDetailViewModel(notes: notes, selectedIndex: selectedIndex)
+            noteDetailViewController.viewModel = viewModel
+        }
     }
     
     
@@ -47,6 +52,12 @@ final class NoteListViewController: UIViewController {
     private func configureCollectionViewLayout() {
         let layout = TagViewFlowLayout()
         self.collectionView.collectionViewLayout = layout
+    }
+    
+    /// 네비게이션 바 초기 설정
+    private func configureNavigationBar() {
+        self.navigationItem.title = self.viewModel.bottleTitle
+        self.navigationItem.backButtonTitle = .empty
     }
 }
 
@@ -85,9 +96,10 @@ extension NoteListViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         
         collectionView.deselectItem(at: indexPath, animated: false)
-        print("link to detail view")
-        // TODO: Detail View 연결
-//        self.performSegue(withIdentifier: "", sender: indexPath)
+        self.performSegue(
+            withIdentifier: SegueIdentifier.showNoteDetailView,
+            sender: indexPath.row
+        )
     }
 }
 
@@ -117,7 +129,7 @@ extension NoteListViewController: UICollectionViewDataSource {
     // swiftlint:enable force_cast
     
     /// 쪽지 색깔, 첫 번쨰 단어를 사용해서 셀 모습 생성
-    func configureCell(_ cell: TagCell,at indexPath: IndexPath) {
+    func configureCell(_ cell: TagCell, at indexPath: IndexPath) {
         let note = self.viewModel.fetchedResultController.object(at: indexPath)
         
         // TODO: 첫 단어 추출 메서드 추가

--- a/Happiggy-bank/Happiggy-bank/ViewController/NoteListViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NoteListViewController.swift
@@ -66,6 +66,7 @@ extension NoteListViewController: UICollectionViewDelegateFlowLayout {
         
         let note = self.viewModel.fetchedResultController.object(at: indexPath)
         
+        /// 현재 셀의 첫 번쨰 단어 길이를 재기 위한 라벨
         let label = UILabel().then {
             $0.font = .systemFont(ofSize: TagCell.Font.firstWordLabel)
             $0.text = note.firstWord
@@ -86,13 +87,84 @@ extension NoteListViewController: UICollectionViewDelegateFlowLayout {
 // MARK: - UICollectionViewDelegate
 extension NoteListViewController: UICollectionViewDelegate {
     
+    func collectionView(
+        _ collectionView: UICollectionView,
+        willDisplay cell: UICollectionViewCell,
+        forItemAt indexPath: IndexPath
+    ) {
+        self.displayWithBouncyAnimation(cell: cell)
+    }
+    
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         
+        guard let cell = collectionView.cellForItem(at: indexPath)
+        else { return }
+        
         collectionView.deselectItem(at: indexPath, animated: false)
-        self.performSegue(
-            withIdentifier: SegueIdentifier.showNoteDetailView,
-            sender: indexPath.row
+        
+        self.bounceOnSelect(cell: cell, atIndexPath: indexPath) { _ in
+            self.performSegue(
+                withIdentifier: SegueIdentifier.showNoteDetailView,
+                sender: indexPath.row
+            )
+        }
+    }
+    
+    /// 탭하는 경우 선택된 셀이 바운스(수축-확대-원 크기로 돌아감)하는 효과
+    private func bounceOnSelect(
+        cell: UICollectionViewCell,
+        atIndexPath indexPath: IndexPath,
+        completion: ((Bool) -> Void)? = nil
+    ) {
+       
+        cell.transform = CGAffineTransform(
+            scaleX: Metric.transformDownScale,
+            y: Metric.transformDownScale
         )
+        
+        UIView.animateKeyframes(withDuration: Metric.cellZoomAnimationDuration, delay: .zero) {
+            UIView.addKeyframe(
+                withRelativeStartTime: .zero,
+                relativeDuration: Metric.upScaleRelativeDuration
+            ) {
+                cell.transform = CGAffineTransform(
+                    scaleX: Metric.transformUpScale,
+                    y: Metric.transformUpScale
+                )
+            }
+            UIView.addKeyframe(
+                withRelativeStartTime: Metric.upScaleRelativeDuration,
+                relativeDuration: Metric.downScaleRelativeDuration
+            ) {
+                cell.transform = .identity
+            }
+        } completion: { result in
+            guard let completion = completion
+            else { return }
+            
+            completion(result)
+        }
+    }
+    
+    /// 위치에 따라 순차적으로 셀들이 바운스하면서 디스플레이되는 효과
+    private func displayWithBouncyAnimation(cell: UICollectionViewCell) {
+        let delayBase = 0.1
+
+        let column = Double(cell.frame.minX / cell.frame.width)
+        let row = Double(cell.frame.minY / cell.frame.height)
+        
+        let distance = sqrt(pow(column, 2) + pow(row, 2))
+        let delay = sqrt(distance) * delayBase
+        cell.transform = CGAffineTransform(scaleX: 0.9, y: 0.9)
+        
+        UIView.animateKeyframes(withDuration: 0.5, delay: delay) {
+            UIView.addKeyframe(withRelativeStartTime: .zero, relativeDuration: 2/3) {
+                cell.transform = CGAffineTransform(scaleX: 1.1, y: 1.1)
+            }
+            UIView.addKeyframe(withRelativeStartTime: 2/3, relativeDuration: 1/3) {
+                cell.transform = .identity
+            }
+        }
     }
 }
 
@@ -100,7 +172,10 @@ extension NoteListViewController: UICollectionViewDelegate {
 // MARK: - UICollectionViewDataSource
 extension NoteListViewController: UICollectionViewDataSource {
     
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    func collectionView(
+        _ collectionView: UICollectionView,
+        numberOfItemsInSection section: Int
+    ) -> Int {
         self.viewModel.fetchedResultController.fetchedObjects?.count ?? .zero
     }
     
@@ -121,11 +196,10 @@ extension NoteListViewController: UICollectionViewDataSource {
     }
     // swiftlint:enable force_cast
     
-    /// 쪽지 색깔, 첫 번쨰 단어를 사용해서 셀 모습 생성
-    func configureCell(_ cell: TagCell, at indexPath: IndexPath) {
+    /// 쪽지 색깔, 첫 번째 단어를 사용해서 셀 모습 생성
+    private func configureCell(_ cell: TagCell, at indexPath: IndexPath) {
         let note = self.viewModel.fetchedResultController.object(at: indexPath)
         
-        // TODO: 첫 단어 추출 메서드 추가
         cell.firstWordLabel.text = note.firstWord
         cell.noteImageView.backgroundColor = .note(color: note.color)
     }

--- a/Happiggy-bank/Happiggy-bank/ViewModel/NoteDetailViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/NoteDetailViewModel.swift
@@ -1,0 +1,45 @@
+//
+//  NoteDetailViewModel.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/03/30.
+//
+
+import UIKit
+
+/// 쪽지 디테일 뷰 컨트롤러의 뷰모델
+final class NoteDetailViewModel {
+    
+    // MARK: - Properties
+    
+    /// 쪽지들
+    var notes: [Note]!
+    
+    /// 유저가 처음 선택한 쪽지의 인덱스
+    var selectedIndex: Int!
+    
+    
+    // MARK: - Init
+    
+    init(notes: [Note], selectedIndex: Int) {
+        self.notes = notes
+        self.selectedIndex = selectedIndex
+    }
+    
+    
+    // MARK: - Functions
+    
+    /// 날짜를 "2022 02.05  토" 형태의 문자열로 연도만 볼드 처리해서 변환
+    func attributedDateString(for note: Note) -> NSMutableAttributedString {
+        note.date
+            .customFormatted(type: .spaceAndDotWithDayOfWeek)
+            .nsMutableAttributedStringify()
+            .color(color: .noteHighlight(for: note.color))
+            .bold(targetString: note.date.yearString, fontSize: Font.dateLabelFontSize)
+    }
+    
+    /// 색상에 따른 쪽지 이미지 리턴
+    func image(for note: Note) -> UIImage {
+        UIImage(named: StringLiteral.listNote + note.color.capitalizedString) ?? UIImage()
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/ViewModel/NoteListViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/NoteListViewModel.swift
@@ -44,6 +44,11 @@ final class NoteListViewModel {
         )
     }()
     
+    /// 저금통 이름
+    private(set) lazy var bottleTitle: String = {
+        self.bottle.title
+    }()
+    
     /// 리스트에서 나타낼 저금통
     private var bottle: Bottle!
     


### PR DESCRIPTION
## 반영 내용
- 이슈 #90 

<br>

- 쪽지 리스트에서 스크롤바 위치 조정을 위해 컬렉션 뷰에 넣었던 마진을 없애고 섹션 인셋을 설정하는 방식으로 전환했습니다
- 쪽지 리스트 스크롤 시, 그리고 셀 선택 시 애니메이션을 추가했습니다
  - 사실 셀 선택 애니메이션이 메인이고 리스트 스크롤은 걍 하는 김에 해본거라 보시고 조잡하다 싶으시면 편하게 알려주세요 머지 전에 삭제하겠습니당
- 쪽지 리스트에서 특정 셀 선택 시 해당 셀의 내용을 담은 쪽지 셀이 중앙에 뜨는 캐러셀 뷰를 구현했습니다.  
  -  https://github.com/zepojo/UPCarouselFlowLayout 를 바탕으로 불필요한 코드를 제거하고 변수 네이밍 등을 수정했습니다. 
  - 일단 지쳐서 지금은 못했는데 캐러셀에서 페이지 넘길 때 햅틱 반응을 추가할까 하는데 혹시 어떠신가용

<br>

## 추후 작업
- 쪽지 디테일 뷰 디자인 피스 되면 해당 사항 반영