### PR TITLE
[feat] 홈뷰컨트롤러, 보틀뷰컨트롤러 리팩토링 #96

### DIFF
--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -40,6 +40,7 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <gestureRecognizers/>
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="ZlX-eS-Yvg" secondAttribute="bottom" id="0m3-gk-sI3"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="dmA-fx-uIw" secondAttribute="trailing" id="26A-HR-Krh"/>
@@ -53,14 +54,26 @@
                             <constraint firstItem="Bmu-YM-ARP" firstAttribute="top" secondItem="ZlX-eS-Yvg" secondAttribute="top" constant="101" id="ucC-5M-Fv0"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Bmu-YM-ARP" secondAttribute="trailing" constant="24" id="x7L-XF-hax"/>
                         </constraints>
+                        <connections>
+                            <outletCollection property="gestureRecognizers" destination="Rh0-a6-UQZ" appends="YES" id="Td2-ul-FSI"/>
+                        </connections>
                     </view>
                     <navigationItem key="navigationItem" id="P6e-3z-28Z"/>
                     <connections>
                         <outlet property="bottleInfoLabel" destination="Bmu-YM-ARP" id="hXu-Ok-U5l"/>
                         <outlet property="homeView" destination="8bC-Xf-vdC" id="edO-Zc-7da"/>
+                        <segue destination="abG-42-vcb" kind="presentation" identifier="presentNewBottleNameField" id="aZQ-BA-T0f"/>
+                        <segue destination="moi-e1-3hQ" kind="presentation" identifier="presentNewNoteDatePicker" id="5ln-YY-tck"/>
+                        <segue destination="FuI-qc-1fd" kind="presentation" identifier="presentNewNoteTextView" id="utJ-Hb-n6A"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+                <exit id="OTp-ev-dcF" userLabel="Exit" sceneMemberID="exit"/>
+                <tapGestureRecognizer id="Rh0-a6-UQZ">
+                    <connections>
+                        <action selector="viewDidTap:" destination="BYZ-38-t0r" id="B5V-2u-FJa"/>
+                    </connections>
+                </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="-1154.4000000000001" y="1642.6108374384237"/>
         </scene>
@@ -371,12 +384,12 @@
                         <outlet property="warningLabel" destination="x1u-nY-DW6" id="pn9-Am-SuF"/>
                         <segue destination="9EN-Ff-rq1" kind="unwind" identifier="unwindFromNoteDatePickerToTextView" unwindAction="unwindCallToNoteTexViewDidArriveWithSegue:" id="Ovp-ZJ-8aW"/>
                         <segue destination="FuI-qc-1fd" kind="presentation" identifier="presentNewNoteTextViewFromDatePicker" id="O5Z-N1-x6E"/>
-                        <segue destination="rAE-WY-Wyc" kind="unwind" identifier="unwindFromNoteDatePickerToBottleView" unwindAction="unwindCallDidArriveWithSegue:" id="Zgm-mw-dYe"/>
+                        <segue destination="OTp-ev-dcF" kind="unwind" identifier="unwindFromNoteDatePickerToHomeView" unwindAction="unwindCallToHomeViewDidArriveWithSegue:sender:" id="8zY-5e-GLC"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4WR-mG-PvL" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-2116" y="3036.9458128078818"/>
+            <point key="canvasLocation" x="-1155" y="2433"/>
         </scene>
         <!--New Note Text View Controller-->
         <scene sceneID="f85-ew-CtQ">
@@ -555,9 +568,8 @@
                         <outletCollection property="colorButtons" destination="YCv-4A-yJI" collectionClass="NSMutableArray" id="Pgw-d9-Cyv"/>
                         <outletCollection property="colorButtons" destination="04d-6x-4Me" collectionClass="NSMutableArray" id="my6-CJ-LfZ"/>
                         <outletCollection property="colorButtons" destination="S3V-4f-gjV" collectionClass="NSMutableArray" id="ht5-ZJ-p7O"/>
-                        <segue destination="rAE-WY-Wyc" kind="unwind" identifier="unwindToBottleViewFromNoteTextView" animates="NO" unwindAction="unwindCallDidArriveWithSegue:" id="S89-mV-zbI"/>
                         <segue destination="moi-e1-3hQ" kind="presentation" identifier="presentDatePickerFromNoteTextView" id="7wk-af-F5w"/>
-                        <segue destination="rAE-WY-Wyc" kind="unwind" identifier="unwindToBottleViewFromNoteTextViewFromSaveButton" unwindAction="unwindCallDidArriveWithSegue:" id="2Dc-9r-8MN"/>
+                        <segue destination="OTp-ev-dcF" kind="unwind" identifier="unwindFromNoteTextViewToHomeView" unwindAction="unwindCallToHomeViewDidArriveWithSegue:sender:" id="Izh-x1-SAi"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="xbT-jH-6dB" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -568,7 +580,7 @@
                     </connections>
                 </tapGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="-3242.4000000000001" y="3036.9458128078818"/>
+            <point key="canvasLocation" x="-156" y="2433"/>
         </scene>
         <!--Bottle View Controller-->
         <scene sceneID="p7l-16-uR7">
@@ -581,9 +593,6 @@
                             <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OAt-vo-L69">
                                 <rect key="frame" x="23" y="0.0" width="344" height="717"/>
                                 <gestureRecognizers/>
-                                <connections>
-                                    <outletCollection property="gestureRecognizers" destination="gEH-ha-I0H" appends="YES" id="I7T-Ve-Zwh"/>
-                                </connections>
                             </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Car-X3-Th6"/>
@@ -597,20 +606,11 @@
                     </view>
                     <connections>
                         <outlet property="bottleNoteView" destination="OAt-vo-L69" id="Xcn-Ec-cu5"/>
-                        <segue destination="moi-e1-3hQ" kind="presentation" identifier="presentNewNoteDatePicker" id="71M-g6-wMS"/>
-                        <segue destination="abG-42-vcb" kind="presentation" identifier="presentNewBottleNameField" id="Qcc-qq-Xqy"/>
-                        <segue destination="FuI-qc-1fd" kind="presentation" identifier="presentNewNoteTextView" id="xNs-XQ-OjW"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4hG-r2-cSC" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-                <exit id="rAE-WY-Wyc" userLabel="Exit" sceneMemberID="exit"/>
-                <tapGestureRecognizer id="gEH-ha-I0H">
-                    <connections>
-                        <action selector="bottleDidTap:" destination="FVx-vN-7Xe" id="tvN-aY-Pt9"/>
-                    </connections>
-                </tapGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="-1154.4000000000001" y="2307.2660098522169"/>
+            <point key="canvasLocation" x="-2280" y="1643"/>
         </scene>
         <!--New Bottle Name Field View Controller-->
         <scene sceneID="BI8-5q-YxJ">
@@ -704,7 +704,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="8DE-rs-fK7" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-330.39999999999998" y="3036.9458128078818"/>
+            <point key="canvasLocation" x="-2142" y="2433"/>
         </scene>
         <!--Note Detail View Controller-->
         <scene sceneID="bNV-s0-R6J">
@@ -808,17 +808,16 @@
                         <outlet property="navigationBar" destination="VaU-DG-hJr" id="tLl-nY-dh1"/>
                         <outlet property="pickerView" destination="JZC-yk-iLa" id="ESS-v4-zWK"/>
                         <outlet property="topLabel" destination="8q5-pU-bsj" id="QQD-EH-FCm"/>
-                        <segue destination="rAE-WY-Wyc" kind="unwind" identifier="unwindFromNewBottlePopupToBottleView" unwindAction="unwindCallDidArriveWithSegue:" id="voH-uq-YvW"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jnb-AF-gmu" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-330" y="3819"/>
+            <point key="canvasLocation" x="-2142" y="3171"/>
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="xNs-XQ-OjW"/>
-        <segue reference="71M-g6-wMS"/>
+        <segue reference="utJ-Hb-n6A"/>
+        <segue reference="5ln-YY-tck"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="checkmark" catalog="system" width="128" height="114"/>

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -283,14 +283,14 @@ enum SegueIdentifier {
     /// 홈 뷰컨트롤러에서 보틀뷰 컨트롤러를 띄울 때 사용
     static let showBottleView = "showBottleView"
     
-    /// 보틀뷰 컨트롤러에서 새 쪽지 날짜 피커뷰 컨트롤러를 띄울 때 사용
+    /// 홈뷰 컨트롤러에서 새 쪽지 날짜 피커뷰 컨트롤러를 띄울 때 사용
     static let presentNewNoteDatePicker = "presentNewNoteDatePicker"
     
-    /// 저금통을 눌렀을 때 새 쪽지 작성뷰 컨트롤러를 띄우는 데 사용
+    /// 홈뷰 컨트롤러에서 새 쪽지 작성뷰 컨트롤러를 띄우는 데 사용
     static let presentNewNoteTextView = "presentNewNoteTextView"
     
-    /// 쪽지 작성뷰 컨트롤러에서 취소 버튼을 눌러서 보틀뷰 컨트롤러로 돌아갈 때 사용
-    static let unwindToBottleViewFromNoteTextView = "unwindToBottleViewFromNoteTextView"
+    /// 쪽지 작성뷰 컨트롤러에서 취소 버튼을 눌러서 홈뷰 컨트롤러로 돌아갈 때 사용
+    static let unwindFromNoteTextViewToHomeView = "unwindFromNoteTextViewToHomeView"
     
     /// 새 유리병 이름 텍스트필드 팝업 띄울 때 사용
     static let presentNewBottleNameField = "presentNewBottleNameField"
@@ -298,7 +298,8 @@ enum SegueIdentifier {
     /// 새 유리병 개봉 날짜 피커 띄울 때 사용
     static let presentNewBottleDatePicker = "presentNewBottleDatePicker"
     
-    static let unwindFromNewBottlePopupToBottleView = "unwindFromNewBottlePopupToBottleView"
+    /// 새 저금통 팝업에서 홈뷰로 돌아갈 때 사용
+    static let unwindFromNewBottlePopupToHomeView = "unwindFromNewBottlePopupToHomeView"
     
     /// 저금통 리스트에서 쪽지 리스트로 넘어갈 때 사용
     static let showNoteList = "showNoteList"
@@ -313,10 +314,7 @@ enum SegueIdentifier {
     static let presentNewNoteTextViewFromDatePicker = "presentNewNoteTextViewFromDatePicker"
     
     /// 새 쪽지 날짜 피커에서 저금통 뷰로 돌아갈 때 사용
-    static let unwindFromNoteDatePickerToBottleView = "unwindFromNoteDatePickerToBottleView"
-    
-    /// 쪽지 작성뷰 컨트롤러에서 저장 버튼을 눌러서 보틀뷰 컨트롤러로 돌아갈 때 사용
-    static let unwindToBottleViewFromNoteTextViewBySave = "unwindToBottleViewFromNoteTextViewFromSaveButton"
+    static let unwindFromNoteDatePickerToHomeView = "unwindFromNoteDatePickerToHomeView"
     
     /// 쪽지 리스트 컨트롤러에서 쪽지 디테일 뷰 컨트롤러를 띄울 때 사용
     static let showNoteDetailView = "showNoteDetailView"

--- a/Happiggy-bank/Happiggy-bank/ViewController/NewBottleDatePickerViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NewBottleDatePickerViewController.swift
@@ -58,7 +58,7 @@ final class NewBottleDatePickerViewController: UIViewController {
         // TODO: Save Data
         saveNewBottle()
         self.performSegue(
-            withIdentifier: SegueIdentifier.unwindFromNewBottlePopupToBottleView,
+            withIdentifier: SegueIdentifier.unwindFromNewBottlePopupToHomeView,
             sender: sender
         )
         self.fadeOut()

--- a/Happiggy-bank/Happiggy-bank/ViewController/NewNoteDatePickerViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NewNoteDatePickerViewController.swift
@@ -69,7 +69,7 @@ final class NewNoteDatePickerViewController: UIViewController {
         }
         if !self.isFromNoteTextView {
             self.performSegue(
-                withIdentifier: SegueIdentifier.unwindFromNoteDatePickerToBottleView,
+                withIdentifier: SegueIdentifier.unwindFromNoteDatePickerToHomeView,
                 sender: self
             )
         }

--- a/Happiggy-bank/Happiggy-bank/ViewController/NewNoteTextViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NewNoteTextViewController.swift
@@ -79,7 +79,7 @@ final class NewNoteTextViewController: UIViewController {
     @IBAction func cancelButtonDidTap(_ sender: UIBarButtonItem) {
         self.endEditingAndFadeOut()
         self.performSegue(
-            withIdentifier: SegueIdentifier.unwindToBottleViewFromNoteTextView, sender: sender
+            withIdentifier: SegueIdentifier.unwindFromNoteTextViewToHomeView, sender: sender
         )
     }
     
@@ -205,14 +205,18 @@ final class NewNoteTextViewController: UIViewController {
         self.letterCountLabel.textColor = self.viewModel.labelColor
     }
     
-    /// 새로운 노트 엔티티를 생성하고 저장하며, 저장 시에 쪽지가 추가되었다는 노티피케이션을 날림
-    private func saveNewNote() {
-        let note = Note.create(
+    /// 새로운 노트 엔티티를 생성
+    private func makeNewNote() -> Note {
+        Note.create(
             date: self.viewModel.newNote.date,
             color: self.viewModel.newNote.color,
             content: self.textView.text,
             bottle: self.viewModel.newNote.bottle
         )
+    }
+    
+    /// 새로 생성한 노트 엔티티를 저장하고 알림을 포스트
+    private func saveAndPostNewNote(_ note: Note) {
         let noteAndDelay = (note: note, delay: CATransition.transitionDuration)
         self.post(name: .noteDidAdd, object: noteAndDelay)
         // TODO: activate core data
@@ -236,12 +240,15 @@ final class NewNoteTextViewController: UIViewController {
         let confirmAction = UIAlertAction(
             title: StringLiteral.confirmButtonTitle,
             style: .default) { _ in
+                
+                let note = self.makeNewNote()
+                
+                self.saveAndPostNewNote(note)
                 self.fadeOut()
                 self.performSegue(
-                    withIdentifier: SegueIdentifier.unwindToBottleViewFromNoteTextViewBySave,
-                    sender: self
+                    withIdentifier: SegueIdentifier.unwindFromNoteTextViewToHomeView,
+                    sender: note
                 )
-                self.saveNewNote()
             }
         
         let cancelAction = UIAlertAction(


### PR DESCRIPTION
## 반영 내용
- 이슈 #96 

<br>

- 보틀뷰 컨트롤러의 역할을 UI다이내믹스 를 사용해 쪽지 노드들을 추가/관리하는 것으로 축소했습니다. 
- 저금통 상태에 따른 배경화면 설정, 유저 탭 인식, 저금통 추가/개봉, 쪽지 추가 뷰들을 띄우는 작업은 모두 홈뷰컨트롤러로 이동했습니다. 
 - 이에 따라 기존에 보틀뷰컨트롤러 에서/로 perform/rewind 되던 segue 를 홈뷰컨트롤러와 연결해줬습니다
 - 저금통 추가 네임필드 segue 는 변경했으나 날짜피커의 경우 이제 홈뷰로 돌아오는 게 아니고 메세지뷰가 추가될 예정이라 불필요한 것 같아 unwind segue 를 삭제만 하고 다시 연결은 하지 않았습니다...!
 - 관련해서 스토리보드도 위치를 전체적으로 수정했습니다...!