### PR TITLE
[feat] 로컬 노티피케이션 기능 추가 #91

### DIFF
--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -87,6 +87,8 @@
 		A8FC07D127B3ECF30077A758 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A8FC07D027B3ECF30077A758 /* Assets.xcassets */; };
 		A8FC07D427B3ECF30077A758 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A8FC07D227B3ECF30077A758 /* LaunchScreen.storyboard */; };
 		A8FC07DD27B3EF030077A758 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = A8FC07DC27B3EF030077A758 /* .swiftlint.yml */; };
+		D22ADF6327F5CE8F00ECB77B /* NotificationSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22ADF6227F5CE8F00ECB77B /* NotificationSettingViewController.swift */; };
+		D22ADF7F27F72F7300ECB77B /* NotificationSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22ADF7E27F72F7300ECB77B /* NotificationSettingViewModel.swift */; };
 		D2C48BFF27E9D60A006FC59E /* Gravity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C48BFE27E9D60A006FC59E /* Gravity.swift */; };
 		D2C48C0127E9DFA1006FC59E /* NoteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C48C0027E9DFA1006FC59E /* NoteView.swift */; };
 /* End PBXBuildFile section */
@@ -173,6 +175,8 @@
 		A8FC07D327B3ECF30077A758 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		A8FC07D527B3ECF30077A758 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A8FC07DC27B3EF030077A758 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		D22ADF6227F5CE8F00ECB77B /* NotificationSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingViewController.swift; sourceTree = "<group>"; };
+		D22ADF7E27F72F7300ECB77B /* NotificationSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingViewModel.swift; sourceTree = "<group>"; };
 		D2C48BFE27E9D60A006FC59E /* Gravity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Gravity.swift; sourceTree = "<group>"; };
 		D2C48C0027E9DFA1006FC59E /* NoteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -209,6 +213,7 @@
 				A8ECD4A627E33BFA00886BC0 /* BottleListViewModel.swift */,
 				A4C1AFD127E5C60E0096CD3E /* NewNoteTextViewModel.swift */,
 				A41DE62727F368BF002A7669 /* NoteDetailViewModel.swift */,
+				D22ADF7E27F72F7300ECB77B /* NotificationSettingViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -278,6 +283,7 @@
 				A490AC4D27DD945E00B04CE1 /* NoteListViewController.swift */,
 				A41DE62527F36595002A7669 /* NoteDetailViewController.swift */,
 				A41DE63127F80115002A7669 /* BottleMessageViewController.swift */,
+				D22ADF6227F5CE8F00ECB77B /* NotificationSettingViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -530,6 +536,7 @@
 				A843332427DA397800A12A54 /* DataProvider.swift in Sources */,
 				A48E183A27E71D9300B44477 /* UILabel+ParagraphStyle.swift in Sources */,
 				A4B2860B27D9B434008769EB /* UIViewController+FadeOut.swift in Sources */,
+				D22ADF7F27F72F7300ECB77B /* NotificationSettingViewModel.swift in Sources */,
 				A4B2860927D9A56A008769EB /* NewNoteTextViewController.swift in Sources */,
 				A48E183C27E7379100B44477 /* CapsuleButton.swift in Sources */,
 				A843332127DA026D00A12A54 /* NewBottleDatePickerViewController.swift in Sources */,
@@ -542,6 +549,7 @@
 				A4B285FD27D8A060008769EB /* Calendar+Duration.swift in Sources */,
 				A41DE63227F80115002A7669 /* BottleMessageViewController.swift in Sources */,
 				A4B2860527D9A546008769EB /* NewNoteDatePickerViewController.swift in Sources */,
+				D22ADF6327F5CE8F00ECB77B /* NotificationSettingViewController.swift in Sources */,
 				A491018527D6EDE90012DFDD /* PersistenceStore.swift in Sources */,
 				A491018D27D7358B0012DFDD /* Bottle+CoreDataClass.swift in Sources */,
 				A41DE62E27F5F2C1002A7669 /* UIView+ZoomAnimation.swift in Sources */,

--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,14 +1,16 @@
 {
-  "pins" : [
-    {
-      "identity" : "then",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/devxoul/Then.git",
-      "state" : {
-        "revision" : "e421a7b3440a271834337694e6050133a3958bc7",
-        "version" : "2.7.0"
+  "object": {
+    "pins": [
+      {
+        "package": "Then",
+        "repositoryURL": "https://github.com/devxoul/Then.git",
+        "state": {
+          "branch": null,
+          "revision": "e421a7b3440a271834337694e6050133a3958bc7",
+          "version": "2.7.0"
+        }
       }
-    }
-  ],
-  "version" : 2
+    ]
+  },
+  "version": 1
 }

--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,16 +1,14 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "Then",
-        "repositoryURL": "https://github.com/devxoul/Then.git",
-        "state": {
-          "branch": null,
-          "revision": "e421a7b3440a271834337694e6050133a3958bc7",
-          "version": "2.7.0"
-        }
+  "pins" : [
+    {
+      "identity" : "then",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/devxoul/Then.git",
+      "state" : {
+        "revision" : "e421a7b3440a271834337694e6050133a3958bc7",
+        "version" : "2.7.0"
       }
-    ]
-  },
-  "version": 1
+    }
+  ],
+  "version" : 2
 }

--- a/Happiggy-bank/Happiggy-bank/AppDelegate.swift
+++ b/Happiggy-bank/Happiggy-bank/AppDelegate.swift
@@ -7,14 +7,16 @@
 
 import CoreData
 import UIKit
+import UserNotifications
 
 @main
-class AppDelegate: UIResponder, UIApplicationDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
 
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        UNUserNotificationCenter.current().delegate = self
         return true
     }
 
@@ -32,6 +34,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
     
+    // MARK: Notification Delegate
+    
+    // 앱 실행 중에도 노티피케이션 받을 수 있음
+    // 필요 없으면 삭제
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        if #available(iOS 14.0, *) {
+            completionHandler([.banner, .list, .sound])
+        } else {
+            completionHandler([.alert, .sound])
+        }
+    }
 
 }
 

--- a/Happiggy-bank/Happiggy-bank/Storyboard/SettingsToggleButtonCell.xib
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/SettingsToggleButtonCell.xib
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -17,30 +18,36 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="알림 설정" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aMc-Fr-qC0">
-                        <rect key="frame" x="0.0" y="52.5" width="67" height="21.5"/>
+                        <rect key="frame" x="36" y="52.5" width="67" height="21.5"/>
                         <fontDescription key="fontDescription" type="system" pointSize="18"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xv5-qA-qQg">
-                        <rect key="frame" x="327" y="47.5" width="51" height="31"/>
-                        <connections>
-                            <action selector="switchDidToggle:" destination="KGk-i7-Jjw" eventType="valueChanged" id="MTb-QX-R4D"/>
-                        </connections>
-                    </switch>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bell" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="65E-Ec-BPO">
+                        <rect key="frame" x="0.0" y="53" width="20" height="19.5"/>
+                        <color key="tintColor" name="customGray"/>
+                        <constraints>
+                            <constraint firstAttribute="width" secondItem="65E-Ec-BPO" secondAttribute="height" multiplier="1:1" id="UpG-8x-2aC"/>
+                        </constraints>
+                    </imageView>
                 </subviews>
                 <constraints>
                     <constraint firstItem="aMc-Fr-qC0" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="7ad-gB-mY9"/>
-                    <constraint firstAttribute="trailing" secondItem="xv5-qA-qQg" secondAttribute="trailing" constant="2" id="wPb-yr-66l"/>
-                    <constraint firstItem="xv5-qA-qQg" firstAttribute="centerY" secondItem="aMc-Fr-qC0" secondAttribute="centerY" id="wg4-ap-hzh"/>
-                    <constraint firstItem="aMc-Fr-qC0" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="zRY-My-o62"/>
+                    <constraint firstItem="65E-Ec-BPO" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="RJ2-55-pes"/>
+                    <constraint firstItem="aMc-Fr-qC0" firstAttribute="leading" secondItem="65E-Ec-BPO" secondAttribute="trailing" constant="16" id="YmW-2Y-jWT"/>
+                    <constraint firstItem="65E-Ec-BPO" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="gEB-GF-hHS"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
-                <outlet property="switch" destination="xv5-qA-qQg" id="gnG-yV-ZZ7"/>
                 <outlet property="titleLabel" destination="aMc-Fr-qC0" id="gfN-3x-1yv"/>
             </connections>
             <point key="canvasLocation" x="173.91304347826087" y="97.098214285714278"/>
         </tableViewCell>
     </objects>
+    <resources>
+        <image name="bell" catalog="system" width="128" height="124"/>
+        <namedColor name="customGray">
+            <color red="0.59999999999999998" green="0.59999999999999998" blue="0.59999999999999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
 </document>

--- a/Happiggy-bank/Happiggy-bank/Subview/SettingsToggleButtonCell.swift
+++ b/Happiggy-bank/Happiggy-bank/Subview/SettingsToggleButtonCell.swift
@@ -7,16 +7,13 @@
 
 import UIKit
 
-/// 환결 설정 뷰 중 토글 스위치가 있는 항목을 위한 셀
+/// 환경 설정 뷰 중 토글 스위치가 있는 항목을 위한 셀
 final class SettingsToggleButtonCell: SettingsViewCell {
     
     // MARK: - @IBOutlets
     
     /// 제목 라벨
     @IBOutlet weak var titleLabel: UILabel!
-    
-    /// 토글 버튼
-    @IBOutlet weak var `switch`: UISwitch!
     
     
     // MARK: - Override Functions
@@ -33,15 +30,6 @@ final class SettingsToggleButtonCell: SettingsViewCell {
     }
     
     override func prepareForReuse() {
-        self.switch.isOn = true
         self.titleLabel.text = .empty
-    }
-    
-    
-    // MARK: - @IBAction
-    
-    /// 스위치가 토글되었을 때 호출되는 액션 메서드
-    @IBAction func switchDidToggle(_ sender: UISwitch) {
-        print("switch toggled")
     }
 }

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -830,3 +830,44 @@ extension BottleMessageViewController {
 
     }
 }
+
+extension NotificationSettingViewController {
+    
+    /// 상수값
+    enum Metric {
+        
+        /// 노티피케이션 반복할 날짜
+        static let repeatingDays: Int = 14
+        
+        /// 스위치 오른쪽 패딩
+        static let trailingPadding: CGFloat = -10
+    }
+    
+    /// 문자열
+    enum StringLiteral {
+
+        /// 노티피케이션 제목
+        static let notificationTitle: String = "행복한 소식!"
+        
+        /// 노티피케이션 내용
+        static let notificationBody: String = "저금통을 열어볼 준비가 되었어요 :)"
+        
+        /// 노티피케이션 식별자
+        static let notificationIdentifier: String = "repeatingNotification"
+        
+        /// UserDefaults의 key로 사용할 문자열
+        static let hasNotificationOn: String = "hasNotificationOn"
+        
+        /// 알림 타이틀
+        static let disabledAlertTitle: String = "알림을 허용해주세요."
+        
+        /// 알림 메시지
+        static let disabledAlertMessage: String = "저금통 개봉 알림을 받으려면 시스템 설정에서 행복 저금통 알림을 허용해주세요."
+        
+        /// 알림 이동 액션 라벨
+        static let move: String = "설정으로 이동"
+        
+        /// 알림 취소 액션 라벨
+        static let cancel: String = "취소"
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -845,7 +845,7 @@ extension NotificationSettingViewController {
     
     /// 문자열
     enum StringLiteral {
-
+        
         /// 노티피케이션 제목
         static let notificationTitle: String = "행복한 소식!"
         

--- a/Happiggy-bank/Happiggy-bank/ViewController/NotificationSettingViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NotificationSettingViewController.swift
@@ -1,0 +1,191 @@
+//
+//  NotificationSettingViewController.swift
+//  Happiggy-bank
+//
+//  Created by Eunbin Kwon on 2022/03/31.
+//
+
+import UIKit
+import UserNotifications
+
+import Then
+
+/// 노티피케이션 스위치 on/off에 따라 노티피케이션 추가/삭제하는 뷰 컨트롤러
+final class NotificationSettingViewController: UIViewController {
+    
+    /// 알림 설정하는 스위치
+    lazy var notificationControl: UISwitch = UISwitch().then {
+        $0.isOn = UserDefaults.standard.bool(forKey: StringLiteral.hasNotificationOn)
+        
+    }
+    
+    /// 날짜 관련 데이터 처리해주는 뷰 모델
+    private var viewModel: NotificationSettingViewModel = NotificationSettingViewModel()
+    
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        configureSwitch()
+        configureSwitchConstraints()
+    }
+    
+    
+    // MARK: @objc functions
+    
+    /// 스위치에 변화가 있을 때 호출되는 objc 함수
+    @objc func switchDidTap(_ sender: UISwitch) {
+        if sender.isOn {
+            requestNotification()
+            scheduleNotifications()
+            return
+        }
+        if !sender.isOn {
+            removeNotifications()
+            return
+        }
+    }
+    
+    
+    // MARK: - Configure UI Components
+    
+    /// 스위치 설정
+    private func configureSwitch() {
+        self.notificationControl.addTarget(
+            self,
+            action: #selector(switchDidTap),
+            for: .valueChanged
+        )
+        self.view.addSubview(notificationControl)
+        UNUserNotificationCenter.current().requestAuthorization { granted, _ in
+            if !granted {
+                DispatchQueue.main.async {
+                    self.notificationControl.isOn = false
+                }
+            }
+        }
+    }
+    
+    
+    // MARK: - Notification related functions
+    
+    /// 노티피케이션 요청
+    private func requestNotification() {
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization(options: [.alert, .sound]) { granted, error in
+            if let error = error {
+                print(error.localizedDescription)
+            }
+            
+            if !granted {
+                UserDefaults.standard.set(false, forKey: StringLiteral.hasNotificationOn)
+                DispatchQueue.main.async {
+                    self.notificationControl.isOn = false
+                    self.alertDisabledState()
+                }
+            }
+        }
+    }
+    
+    /// 설정에서 알림 꺼져있을 때 나타내는 알림창
+    private func alertDisabledState() {
+        let alert = UIAlertController(
+            title: StringLiteral.disabledAlertTitle,
+            message: StringLiteral.disabledAlertMessage,
+            preferredStyle: .alert
+        )
+        
+        alert.addAction(
+            UIAlertAction(
+                title: StringLiteral.move,
+                style: .default
+            ) { _ in
+                self.openSettings()
+            }
+        )
+        alert.addAction(
+            UIAlertAction(
+                title: StringLiteral.cancel,
+                style: .cancel
+            )
+        )
+        
+        self.present(alert, animated: true)
+    }
+    
+    /// 설정으로 이동
+    private func openSettings() {
+        if let bundle = Bundle.main.bundleIdentifier,
+           let settings = URL(string: UIApplication.openSettingsURLString + bundle) {
+            if UIApplication.shared.canOpenURL(settings) {
+                UIApplication.shared.open(settings)
+            }
+        }
+    }
+    
+    /// 노티피케이션 스케줄링
+    private func scheduleNotifications() {
+        let center = UNUserNotificationCenter.current()
+        
+        center.getNotificationSettings { settings in
+            guard settings.authorizationStatus == .authorized
+            else { return }
+            
+            // 특정 기간동안 반복되는 알림 설정
+            for day in 0...Metric.repeatingDays {
+                let repeatingNotificationRequest = self.repeatingNotificationRequest(byAdding: day)
+                center.add(repeatingNotificationRequest) { error in
+                    if let error = error {
+                        print(error.localizedDescription)
+                    }
+                }
+            }
+            UserDefaults.standard.set(true, forKey: StringLiteral.hasNotificationOn)
+        }
+    }
+    
+    /// 노티피케이션 리퀘스트 만들어주는 함수
+    private func repeatingNotificationRequest(byAdding day: Int) -> UNNotificationRequest {
+        let content = UNMutableNotificationContent()
+        let trigger = UNCalendarNotificationTrigger(
+            dateMatching: self.viewModel.repeatingDateComponent(byAdding: day),
+            repeats: false
+        )
+        content.title = StringLiteral.notificationTitle
+        content.body = StringLiteral.notificationBody
+        content.sound = .default
+        
+        return UNNotificationRequest(
+            identifier: StringLiteral.notificationIdentifier + "\(day)",
+            content: content,
+            trigger: trigger
+        )
+    }
+    
+    /// 전달된, 대기중인 모든 노티피케이션 삭제
+    private func removeNotifications() {
+        let center = UNUserNotificationCenter.current()
+        
+        center.removeAllDeliveredNotifications()
+        center.removeAllPendingNotificationRequests()
+        UserDefaults.standard.set(false, forKey: StringLiteral.hasNotificationOn)
+    }
+    
+    
+    // MARK: - Constraints
+    
+    /// 스위치 오토레이아웃 설정
+    private func configureSwitchConstraints() {
+        self.notificationControl.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.notificationControl.centerYAnchor.constraint(
+                equalTo: self.view.centerYAnchor
+            ),
+            self.notificationControl.trailingAnchor.constraint(
+                equalTo: self.view.trailingAnchor, constant: Metric.trailingPadding
+            )
+        ])
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/ViewController/SettingsViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/SettingsViewController.swift
@@ -59,7 +59,10 @@ extension SettingsViewController: UITableViewDataSource {
         Content.allCases.count
     }
 
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    func tableView(
+        _ tableView: UITableView,
+        cellForRowAt indexPath: IndexPath
+    ) -> UITableViewCell {
         
         if indexPath.row == Content.bottleAlertSettings.rawValue {
             
@@ -68,7 +71,7 @@ extension SettingsViewController: UITableViewDataSource {
                 for: indexPath
             ) as? SettingsToggleButtonCell
             else { return SettingsToggleButtonCell() }
-            
+            addNotificationSettingViewController(to: cell)
             return cell
         }
         
@@ -83,6 +86,29 @@ extension SettingsViewController: UITableViewDataSource {
         }
         
         return SettingsViewCell()
+    }
+    
+    /// 노티피케이션 셀에 뷰 컨트롤러 추가
+    private func addNotificationSettingViewController(to cell: SettingsToggleButtonCell) {
+        let viewController = NotificationSettingViewController()
+        self.addChild(viewController)
+        cell.contentView.addSubview(viewController.view)
+        
+        viewController.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            viewController.view.leadingAnchor.constraint(
+                equalTo: cell.contentView.leadingAnchor
+            ),
+            viewController.view.trailingAnchor.constraint(
+                equalTo: cell.contentView.trailingAnchor
+            ),
+            viewController.view.topAnchor.constraint(
+                equalTo: cell.contentView.topAnchor
+            ),
+            viewController.view.bottomAnchor.constraint(
+                equalTo: cell.contentView.bottomAnchor
+            )
+        ])
     }
 }
 

--- a/Happiggy-bank/Happiggy-bank/ViewModel/NotificationSettingViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/NotificationSettingViewModel.swift
@@ -1,0 +1,34 @@
+//
+//  NotificationSettingViewModel.swift
+//  Happiggy-bank
+//
+//  Created by Eunbin Kwon on 2022/04/01.
+//
+
+import UIKit
+
+/// 노티피케이션 관련 데이터 처리하는 뷰 모델
+final class NotificationSettingViewModel {
+    
+    lazy var bottle: Bottle = {
+        let request = Bottle.fetchRequest(isOpen: false)
+        let bottles = PersistenceStore.shared.fetch(request: request)
+        guard let bottle = bottles.first
+        else { return Bottle() }
+        return bottle
+    }()
+    
+    func repeatingDateComponent(byAdding day: Int) -> DateComponents {
+        let endDate = bottle.endDate
+        if let repeatingDate = Calendar.current.date(
+            byAdding: DateComponents(day: day),
+            to: endDate
+        ) {
+            return Calendar.current.dateComponents(
+                [.year, .month, .day, .hour, .minute],
+                from: repeatingDate
+            )
+        }
+        return DateComponents()
+    }
+}


### PR DESCRIPTION
## 반영 내용
issue #91 

## 주요 변경사항
- SettingsToggleButtonCell의 스위치 삭제
- NotificationSettingViewController 추가 및 스위치 관련 기능 추가

### SettingsToggleButtonCell.swift, .xib
- 스위치 삭제 및 변경된 디자인에 따라 아이콘 뷰 추가
    - 버전 셀에도 적용하려고 했는데 버전 셀 구조 자체가 바뀌는 것 같아서 일단 안 건드렸습니다.

### SettingsViewController
- SettingsToggleButtonCell에 뷰 컨트롤러 추가

### NotificationSettingViewController, ViewModel
- 노티피케이션 관련 로직 추가
- 처음 스위치 눌렀을 때 -> 요청
    - granted : 스위치 on, 현재 진행중인 저금통 종료 기간에 따라 14일간 노티피케이션 스케줄링
    - disabled: 스위치 off
- 이후 스위치 눌렀을 때
    - granted
        - on: 위와 동일
        - off: 스케줄링된 모든 노티피케이션 삭제 
    - disabled: 스위치 off, 시스템 설정 변경하라는 알림창 띄움.

**확인사항**
- 노티피케이션 줄 기간 현재 14일로 지정. 논의 후 변경 가능.

### 추후 작업
- 저금통 개봉시 노티피케이션 삭제
- 저금통 endDate 자정으로 저장