### PR TITLE
[feat] 개발자에게 메일 보내기 구현 #95

### DIFF
--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -234,7 +234,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="108" estimatedRowHeight="108" sectionHeaderHeight="28" estimatedSectionHeaderHeight="-1" sectionFooterHeight="28" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="XH5-F4-UT7">
-                                <rect key="frame" x="0.0" y="88" width="390" height="573"/>
+                                <rect key="frame" x="0.0" y="88" width="390" height="576.33333333333337"/>
                                 <inset key="separatorInset" minX="24" minY="0.0" maxX="24" maxY="0.0"/>
                                 <connections>
                                     <outlet property="dataSource" destination="IlI-sf-Vas" id="nPy-Qt-GrC"/>
@@ -242,32 +242,36 @@
                                 </connections>
                             </tableView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="b4d-oF-HEA">
-                                <rect key="frame" x="125.66666666666669" y="677" width="139" height="60"/>
+                                <rect key="frame" x="115.33333333333333" y="680.33333333333337" width="159.66666666666669" height="56.666666666666629"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Happigy" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3QJ-R7-7AU">
-                                        <rect key="frame" x="0.0" y="0.0" width="139" height="18"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Happiggy" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3QJ-R7-7AU">
+                                        <rect key="frame" x="0.0" y="0.0" width="159.66666666666666" height="17"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" name="customGray"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="QIP-2t-A8R">
-                                        <rect key="frame" x="0.0" y="25" width="139" height="35"/>
+                                        <rect key="frame" x="0.0" y="23.999999999999996" width="159.66666666666666" height="32.666666666666657"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2unbin mseo sun h1" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pBU-xg-BjY">
-                                                <rect key="frame" x="0.0" y="0.0" width="139" height="18"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="159.66666666666666" height="17"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <color key="textColor" name="customGray"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="github.com/Happiggy" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rpq-ey-KQm">
-                                                <rect key="frame" x="0.0" y="18" width="139" height="17"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="happiggybank@gmail.com" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rpq-ey-KQm">
+                                                <rect key="frame" x="0.0" y="17" width="159.66666666666666" height="15.666666666666664"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                 <color key="textColor" name="customGray"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
                                     </stackView>
                                 </subviews>
+                                <gestureRecognizers/>
+                                <connections>
+                                    <outletCollection property="gestureRecognizers" destination="lsy-he-ebl" appends="YES" id="6EQ-Qb-XdG"/>
+                                </connections>
                             </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="NL0-gI-uP8"/>
@@ -289,6 +293,11 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="aNi-4h-ywR" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <tapGestureRecognizer id="lsy-he-ebl">
+                    <connections>
+                        <action selector="teamLabelDidTap:" destination="IlI-sf-Vas" id="J5n-bv-v6a"/>
+                    </connections>
+                </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="2965.5999999999999" y="1642.6108374384237"/>
         </scene>

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -695,6 +695,16 @@ extension SettingsViewController {
         /// 앱 버전 정보
         case appVersionInformation
     }
+    
+    /// 메일 앱 관련 문자열
+    enum Mail {
+        
+        /// 수신인: 팀 이메일
+        static let recipients = ["happiggybank@gmail.com"]
+        
+        /// 제목: [행복저금통]
+        static let subject = "[행복저금통]"
+    }
 }
 
 extension SettingsViewCell {

--- a/Happiggy-bank/Happiggy-bank/ViewController/SettingsViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/SettingsViewController.swift
@@ -5,6 +5,7 @@
 //  Created by sun on 2022/03/22.
 //
 
+import MessageUI
 import UIKit
 
 /// 환경 설정 뷰 컨트롤러
@@ -27,6 +28,17 @@ final class SettingsViewController: UIViewController {
         self.registerCells()
     }
     
+    
+    // MARK: - @IBActions
+    
+    /// 팀 라벨이 탭 되었을 때 호출되는 메서드
+    @IBAction func teamLabelDidTap(_ sender: UITapGestureRecognizer) {
+        self.presentMailApp()
+    }
+    
+    
+    // MARK: - Functions
+    
     /// 테이블 뷰 셀 등록
     private func registerCells() {
         self.tableView.register(
@@ -38,7 +50,6 @@ final class SettingsViewController: UIViewController {
             forCellReuseIdentifier: SettingsToggleButtonCell.name
         )
     }
-    
 }
 
 
@@ -72,5 +83,33 @@ extension SettingsViewController: UITableViewDataSource {
         }
         
         return SettingsViewCell()
+    }
+}
+
+
+// MARK: - MFMailComposeViewControllerDelegate
+/// 메일 관련 메서드, 프로퍼티
+extension SettingsViewController: MFMailComposeViewControllerDelegate {
+    
+    func mailComposeController(
+        _ controller: MFMailComposeViewController,
+        didFinishWith result: MFMailComposeResult,
+        error: Error?
+    ) {
+        controller.dismiss(animated: true)
+    }
+    
+    /// 메일 앱을 모달 뷰로 띄우는 메서드
+    private func presentMailApp() {
+        guard MFMailComposeViewController.canSendMail()
+        else { return }
+        
+        let mailViewController = MFMailComposeViewController().then {
+            $0.mailComposeDelegate = self
+            $0.setToRecipients(Mail.recipients)
+            $0.setSubject(Mail.subject)
+        }
+        // TODO: add haptic selection feedback
+        present(mailViewController, animated: true)
     }
 }


### PR DESCRIPTION
## 반영 내용
- 이슈 #95 

<br>

### 환경 설정에서 개발자에게 메일 보내기 구현
- 뷰 하단의 팀 라벨을 누르면 메일을 보낼 수 있는 경우에만 메일 작성창이 모달로 뜨게 했습니다. 
  - 제목은 [행복저금통] 이 자동으로 들어가도록 했고, 
  - 내용에도 간단한 안내(e.g. 버그 발생 시 디바이스 이름, iOS 버전을 함께 알려주시면 감사하겠습니다)를 쓸 수는 있는데 일단은 공백으로 뒀습니당 
  - 다른 풀리퀘에 코드가 있어서, 추후에 작성창을 띄울때 햅틱을 추가할 예정입니다.
- 메일을 보낼 수 없는 경우에는 굳이 알림을 띄울 필요가 없다고 생각해서 아무것도 하지 않게 했습니다. 
- 유저가 메일 창에서 작업을 하고 다시 앱으로 돌아왔을 때 상태에 따라 알림을 띄울 수 있는데(전송, 저장,에러 등) 알림을 띄울 사안인가 싶어서 일단 그냥 뒀고, 관련해서 의견 주시면 감사하겠습니다!

<br>

## 추후 작업
- (논의 후 필요하면) 결과 처리, 햅틱 추가