### PR TITLE
[feat] 쪽지 태그 리스트 디자인 반영 #101

### DIFF
--- a/Happiggy-bank/Happiggy-bank/Assets.xcassets/note-colors/noteListTagWhite.colorset/Contents.json
+++ b/Happiggy-bank/Happiggy-bank/Assets.xcassets/note-colors/noteListTagWhite.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF9",
+          "green" : "0xF9",
+          "red" : "0xF9"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Happiggy-bank/Happiggy-bank/CoreData/Note+CoreDataClass.swift
+++ b/Happiggy-bank/Happiggy-bank/CoreData/Note+CoreDataClass.swift
@@ -88,17 +88,17 @@ public class Note: NSManagedObject {
     var bottle: Bottle { self.bottle_ ?? Bottle() }
     
     /// 내용의 첫 번째 유효한 단어
-    var firstWord: String {
+    lazy var firstWord: String = {
         
         var firstWord = self.content
             .components(separatedBy: NSCharacterSet.whitespacesAndNewlines)
             .first { !$0.isEmpty } ?? .empty
 
-        /// 첫 단어가 10글자를 넘으면 10글자까지만 자름
+        /// 첫 단어가 10글자를 넘으면 1...10 의 범위에서 랜덤으로 길이 설정
         if firstWord.count > Metric.firstWordMaxLength {
-            firstWord = String(firstWord.prefix(Metric.firstWordMaxLength))
+            firstWord = String(firstWord.prefix(Metric.firstWordRandomLength))
         }
         
         return firstWord
-    }
+    }()
 }

--- a/Happiggy-bank/Happiggy-bank/Extensions/UIColor+AssetColors.swift
+++ b/Happiggy-bank/Happiggy-bank/Extensions/UIColor+AssetColors.swift
@@ -35,6 +35,9 @@ extension UIColor {
     /// 연한 회색
     static let customLightGray = UIColor(named: "customLightGray")
     
+    /// 쪽지 리스트 태그 셀 흰색 쪽지 색상
+    static let tagCellWhite = UIColor(named: "noteListTagWhite")
+    
     
     // MARK: - Functions
     

--- a/Happiggy-bank/Happiggy-bank/Subview/TagCell.swift
+++ b/Happiggy-bank/Happiggy-bank/Subview/TagCell.swift
@@ -14,12 +14,9 @@ final class TagCell: UICollectionViewCell {
     
     /// 첫 단어 라벨
     let firstWordLabel = UILabel().then {
-        $0.font = .systemFont(ofSize: Font.firstWordLabel)
+        $0.font = .boldSystemFont(ofSize: Font.firstWordLabel)
         $0.textAlignment = .center
     }
-    
-    /// 쪽지 배경 이미지
-    let noteImageView = UIImageView()
     
     
     // MARK: - Inits
@@ -28,7 +25,7 @@ final class TagCell: UICollectionViewCell {
         super.init(frame: frame)
         
         self.configureHierarchy()
-        self.configureConstraints()
+        self.configureFirstWordLabelConstraints()
     }
     
     required init?(coder: NSCoder) {
@@ -41,36 +38,18 @@ final class TagCell: UICollectionViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         
-        self.noteImageView.image = UIImage()
-        self.firstWordLabel.text = nil
+        self.firstWordLabel.attributedText = nil
         self.transform = .identity
     }
     
     
-    // MARK: - Functions 
+    // MARK: - Functions
+    
     /// 뷰 체계 설정
     private func configureHierarchy() {
-        self.noteImageView.translatesAutoresizingMaskIntoConstraints = false
         self.firstWordLabel.translatesAutoresizingMaskIntoConstraints = false
         
-        self.contentView.addSubview(self.noteImageView)
         self.contentView.addSubview(self.firstWordLabel)
-    }
-    
-    /// 오토레이아웃 설정
-    private func configureConstraints() {
-        self.configureNoteImageViewConstraints()
-        self.configureFirstWordLabelConstraints()
-    }
-    
-    /// 쪽지 이미지뷰 오토레이아웃
-    private func configureNoteImageViewConstraints() {
-        NSLayoutConstraint.activate([
-            self.noteImageView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            self.noteImageView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            self.noteImageView.topAnchor.constraint(equalTo: self.topAnchor),
-            self.noteImageView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
-        ])
     }
     
     /// 단어 라벨 오토레이아웃

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -275,8 +275,13 @@ extension Note {
     /// Note 엔티티에서 사용하는 상수
     enum Metric {
         
-        /// 첫 단어 최대 길이로, 이 길이를 초과하면 해당 글자까지 자름
+        /// 첫 단어 최대 길이(10자)로, 이 길이를 초과하면 해당 글자까지 자름
         static let firstWordMaxLength: Int = 10
+        
+        /// 첫 단어가 최대 길이(10자)를 초과하는 경우 랜덤으로 1~최대 길이의 범위 내의 숫자를 길이로 설정
+        static var firstWordRandomLength: Int {
+            (1...firstWordMaxLength).randomElement() ?? 3
+        }
     }
     
     /// Note 엔티티에서 설정하는 문자열

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -541,8 +541,8 @@ extension NoteListViewController {
         /// 첫 단어 라벨 위아래 패딩: 16
         static let firstWordLabelVerticalPadding: CGFloat = 16
         
-        /// 첫 단어 라벨 좌우 패딩: 16
-        static let firstWordLabelHorizontalPadding: CGFloat = 16
+        /// 첫 단어 라벨 좌우 패딩: 24
+        static let firstWordLabelHorizontalPadding: CGFloat = 24
         
         /// 2
         static let two = 2.0
@@ -706,8 +706,8 @@ extension TagCell {
     /// TagCell 폰트
     enum Font {
         
-        /// 첫 단어 라벨 폰트 크기: 17
-        static let firstWordLabel: CGFloat = 17
+        /// 첫 단어 라벨 폰트 크기: 18
+        static let firstWordLabel: CGFloat = 18
     }
 }
 

--- a/Happiggy-bank/Happiggy-bank/ViewController/NoteListViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NoteListViewController.swift
@@ -172,8 +172,10 @@ extension NoteListViewController: UICollectionViewDataSource {
     private func configureCell(_ cell: TagCell, at indexPath: IndexPath) {
         let note = self.viewModel.fetchedResultController.object(at: indexPath)
         
-        cell.firstWordLabel.text = note.firstWord
-        cell.noteImageView.backgroundColor = .note(color: note.color)
+        cell.firstWordLabel.attributedText = self.viewModel.attributedFirstWordString(
+            forNote: note
+        )
+        cell.contentView.backgroundColor = self.viewModel.tagColor(forNote: note)
     }
 }
 

--- a/Happiggy-bank/Happiggy-bank/ViewModel/NoteListViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/NoteListViewModel.swift
@@ -71,4 +71,18 @@ final class NoteListViewModel {
         self.fetchedResultsControllerDelegate = fetchedResultContollerDelegate
     }
     
+    
+    // MARK: - Functions
+    
+    /// 태그 셀의 배경 색깔 리턴
+    func tagColor(forNote note: Note) -> UIColor? {
+        (note.color != .white) ? .note(color: note.color) : .tagCellWhite 
+    }
+    
+    /// 첫 단어를 색깔 변환한 문자열
+    func attributedFirstWordString(forNote note: Note) -> NSMutableAttributedString {
+        note.firstWord
+            .nsMutableAttributedStringify()
+            .color(color: .noteHighlight(for: note.color))
+    }
 }


### PR DESCRIPTION
## 반영 내용
- 이슈 #101 

<br>

- 태그 셀 색상, 글씨 크기, 굵기, 여백을 반영했습니다
- 첫 단어가 10자를 초과하는 경우 1~10 글자 사이에 랜덤으로 자르게 했습니다 
  - 띄어쓰기를 하지 않는 유저의 경우 모든 셀 크기가 같으면 단조로울 것이라고 생각해 이렇게 처리했습니다(저희 목 데이터처럼...)
  - 관련해서 기존 왼쪽 정렬 로직에서 버그를 발견해 정렬 로직을 변경했습니다 
- 쪽지 개수가 한 페이지 안에 들어가는 경우 섹션 자체를 가운데 정렬했습니다