### PR TITLE
[fix] 저금통 리스트 탭 누른 뒤 개봉하는 경우 쪽지 리스트로 넘어가지 않는 문제 해결 #109

### DIFF
--- a/Happiggy-bank/Happiggy-bank/ViewController/BottleListViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/BottleListViewController.swift
@@ -39,12 +39,27 @@ final class BottleListViewController: UIViewController {
         scrollToOpenBottleIfNeeded()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        guard let bottle =  self.viewModel.openingBottle
+        else {
+            self.showAllSubviews()
+            self.configureEmptyLabel()
+            return
+        }
+        self.hideAllSubviewsIfIsOpeningBottle(bottle)
+        self.scrollToOpenBottleIfNeeded()
+        self.performSegue(withIdentifier: SegueIdentifier.showNoteList, sender: bottle)
+    }
+    
     
     // MARK: - @IBActions
     
     /// 해당 뷰 컨트롤러로 언와인드 되었을 때 호출
     @IBAction func unwindCallToBottleListDidArrive(segue: UIStoryboardSegue) {
-        guard let bottle = self.viewModel.openingBottle
+        guard let bottle = self.viewModel.openingBottle,
+              self.viewIfLoaded == nil
         else { return }
         
         self.performSegue(withIdentifier: SegueIdentifier.showNoteList, sender: bottle)
@@ -114,6 +129,28 @@ final class BottleListViewController: UIViewController {
         
         self.tableView.scrollToRow(at: indexPath, at: .middle, animated: false)
         self.viewModel.openingBottleIndexPath = nil
+    }
+    
+    /// 네비게이션 바, 탭바와 모든 하위 뷰를 다시 나타냄
+    private func showAllSubviews() {
+        self.title = viewModel.bottleList.isEmpty ?
+        StringLiteral.emptyListNavigationBarTitle :
+        StringLiteral.fullListNavigationBarTitle
+        
+        self.view.subviews.forEach {
+            $0.isHidden = false
+        }
+        
+        self.tabBarController?.tabBar.isHidden = false
+    }
+    
+    /// 네비게이션 바, 탭바와 모든 하위 뷰를 숨김
+    private func hideAllSubviewsIfIsOpeningBottle(_ bottle: Bottle) {
+        self.view.subviews.forEach {
+            $0.isHidden = true
+        }
+        self.tabBarController?.tabBar.isHidden = true
+        self.navigationItem.title = .empty
     }
 }
 


### PR DESCRIPTION
## 반영내용 
- 이슈 #109 

<br>

저금통 탭을 누른 후 개봉하게 되면 이미 저금통 탭이 로드된 상태라서 반드시 저금통 리스트에 돌아오면 뷰가 다시 나타나게 되기 때문에 작동하지 않는 문제였습니다...저금통 탭을 누르기 전에는 저금통 리스트 뷰가 로드만 되고 나타나기 전에 쪽지리스트 segue 로 넘어가버려서 해당 애니메이션이 보이지 않았던 것 같은데 사실 이래도 되는건가 싶은 생각이 들긴 합니다...이것저것 해봤는데 스토리보드+현재 구조에서는 마땅한 대안이 없는 거 같아요 나중에 도움 주시면 매우 감사하겠습니다 흑흑 

<br>

일단은 임시방편으로 저금통 리스트 뷰가 이미 로드된 경우에는 리스트 뷰를 모두 숨겨버려서 마치 애니메이션 탭에서 넘어온것처럼 보이게 했습니다!