### PR TITLE
[fix] 홈뷰에서 디바이스 크기에 따라 bottle note view 크기가 조정되도록 변경 #112

### DIFF
--- a/Happiggy-bank/Happiggy-bank/CoreData/Bottle+CoreDataClass.swift
+++ b/Happiggy-bank/Happiggy-bank/CoreData/Bottle+CoreDataClass.swift
@@ -183,12 +183,12 @@ extension Bottle {
     
     /// 테스트용 목 데이터
     static let foo: Bottle = {
-        let count = 355 - 2
+        let count = 365
         let startDate = nthDayFromToday(-count)
         let endDate = nthDayFromToday(-1)
         
         let bottle = Bottle(title: "행복냠냠이", startDate: startDate, endDate: endDate, message: "안녕")
-        for index in 5..<count {
+        for index in 0..<count {
             let note = Note.create(
                 date: nthDayFromToday(-index-1),
                 color: NoteColor.allCases.randomElement()!,

--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -330,7 +330,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="108" estimatedRowHeight="108" sectionHeaderHeight="28" estimatedSectionHeaderHeight="-1" sectionFooterHeight="28" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="XH5-F4-UT7">
-                                <rect key="frame" x="0.0" y="88" width="375" height="541"/>
+                                <rect key="frame" x="0.0" y="88" width="375" height="544.33333333333337"/>
                                 <inset key="separatorInset" minX="24" minY="0.0" maxX="24" maxY="0.0"/>
                                 <connections>
                                     <outlet property="dataSource" destination="IlI-sf-Vas" id="nPy-Qt-GrC"/>
@@ -338,7 +338,7 @@
                                 </connections>
                             </tableView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="b4d-oF-HEA">
-                                <rect key="frame" x="118" y="645" width="139" height="60"/>
+                                <rect key="frame" x="107.66666666666667" y="648.33333333333337" width="159.66666666666663" height="56.666666666666629"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Happiggy" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3QJ-R7-7AU">
                                         <rect key="frame" x="0.0" y="0.0" width="159.66666666666666" height="17"/>

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -65,8 +65,10 @@ extension BottleViewController {
         static let durationCap = 60
         
         /// 일주일, 한 달인 경우 높이를 축소하기 위해 감산해줄 값
-        static let shorterMonthHeightRemovalConstant: CGFloat = 90
+        static let shorterMonthHeightRemovalConstant: CGFloat = 130
         
+        /// 저금통 쪽지 뷰 좌우 여백: 14
+        static let bottleNoteViewDxInset: CGFloat = 14
     }
 }
 

--- a/Happiggy-bank/Happiggy-bank/ViewController/BottleViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/BottleViewController.swift
@@ -65,8 +65,6 @@ final class BottleViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.addObservers()
-        
-        initializeBottleView()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -79,6 +77,15 @@ final class BottleViewController: UIViewController {
         super.viewWillDisappear(animated)
         
         self.gravity?.disable()
+    }
+    
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+        
+        guard self.gravity == nil,
+              self.bottleNoteView != nil
+        else { return }
+        self.initializeBottleView()
     }
     
     
@@ -101,8 +108,14 @@ final class BottleViewController: UIViewController {
         guard let bottle = self.viewModel.bottle
         else { return }
         
+        /// 디바이스 크기에 따라 쪽지를 담을 영역 크기 조정
+        self.bottleNoteView.frame = self.view.bounds.insetBy(
+            dx: Metric.bottleNoteViewDxInset,
+            dy: .zero
+        )
         self.fillBottleNoteView(fromNotes: bottle.notes)
         self.addGravity()
+        self.gravity?.enable()
     }
     
     /// 현재 뷰 컨트롤러로 unwind 하라는 호출을 받았을 때 실행되는 액션메서드로, 중력 효과 재개


### PR DESCRIPTION
## 반영 내용
- 이슈 #112 

<br>

- 스토리보드는 viewDidLoad 시점에 아직 하위 뷰들이 로드되지 않고, 디바이스 크기가 반영되지 않아 쪽지를 추가하는 영역이 변화하지 않고 있었습니다. 따라서 viewWillLayoutSubviews 로 관련 작업을 이동하고, gravity 가 널인지, 하위뷰들이 로드 되었는지 확인해서 최초에 한 번만 관련 작업을 수행하도록 했습니다...!

<br>

와..! 홈뷰 주요 기능이었는데 지금까지 몰랐다니..! 와 이슈 넘버도 112...! 와...!