### PR TITLE
[feat] 홈 화면 UI 재구성 및 기능 추가 #63, #81, #123

### DIFF
--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		D22ADF7F27F72F7300ECB77B /* NotificationSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22ADF7E27F72F7300ECB77B /* NotificationSettingViewModel.swift */; };
 		D236DB8627FDC43200D7B8F0 /* NewBottleDatePickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D236DB8527FDC43200D7B8F0 /* NewBottleDatePickerViewModel.swift */; };
 		D236DB8827FDD66900D7B8F0 /* NewBottleMessageFieldViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D236DB8727FDD66900D7B8F0 /* NewBottleMessageFieldViewController.swift */; };
+		D284A5DE27FF3EFB00D20699 /* BottleNameEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D284A5DD27FF3EFB00D20699 /* BottleNameEditViewController.swift */; };
 		D2C48BFF27E9D60A006FC59E /* Gravity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C48BFE27E9D60A006FC59E /* Gravity.swift */; };
 		D2C48C0127E9DFA1006FC59E /* NoteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C48C0027E9DFA1006FC59E /* NoteView.swift */; };
 /* End PBXBuildFile section */
@@ -181,6 +182,7 @@
 		D22ADF7E27F72F7300ECB77B /* NotificationSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingViewModel.swift; sourceTree = "<group>"; };
 		D236DB8527FDC43200D7B8F0 /* NewBottleDatePickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBottleDatePickerViewModel.swift; sourceTree = "<group>"; };
 		D236DB8727FDD66900D7B8F0 /* NewBottleMessageFieldViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBottleMessageFieldViewController.swift; sourceTree = "<group>"; };
+		D284A5DD27FF3EFB00D20699 /* BottleNameEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleNameEditViewController.swift; sourceTree = "<group>"; };
 		D2C48BFE27E9D60A006FC59E /* Gravity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Gravity.swift; sourceTree = "<group>"; };
 		D2C48C0027E9DFA1006FC59E /* NoteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -290,6 +292,7 @@
 				A41DE63127F80115002A7669 /* BottleMessageViewController.swift */,
 				D22ADF6227F5CE8F00ECB77B /* NotificationSettingViewController.swift */,
 				D236DB8727FDD66900D7B8F0 /* NewBottleMessageFieldViewController.swift */,
+				D284A5DD27FF3EFB00D20699 /* BottleNameEditViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -526,6 +529,7 @@
 				D236DB8627FDC43200D7B8F0 /* NewBottleDatePickerViewModel.swift in Sources */,
 				A499318327BF5158009FF5A8 /* BottleNoteView.swift in Sources */,
 				A4CF2C8E27CBA49D001B01B1 /* UIViewController+NotificationCenter.swift in Sources */,
+				D284A5DE27FF3EFB00D20699 /* BottleNameEditViewController.swift in Sources */,
 				A8BD834D27BE39D600E0DE41 /* NoteProgressLabel.swift in Sources */,
 				A8509E6E27C89A1200855153 /* UIColor+Extension.swift in Sources */,
 				D236DB8827FDD66900D7B8F0 /* NewBottleMessageFieldViewController.swift in Sources */,

--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -28,12 +28,33 @@
                                     <segue destination="FVx-vN-7Xe" kind="embed" identifier="showBottleView" id="rLd-zf-USa"/>
                                 </connections>
                             </containerView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Bmu-YM-ARP">
-                                <rect key="frame" x="24" y="101" width="366" height="61"/>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="homeCharacter" translatesAutoresizingMaskIntoConstraints="NO" id="dfo-Bk-tQ1">
+                                <rect key="frame" x="0.0" y="241" width="414" height="414"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" secondItem="Bmu-YM-ARP" secondAttribute="height" multiplier="361:60" id="DAh-Xr-abF"/>
+                                    <constraint firstAttribute="width" secondItem="dfo-Bk-tQ1" secondAttribute="height" multiplier="1:1" id="ukt-oa-FWq"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mxw-FV-eBm">
+                                <rect key="frame" x="23" y="174" width="77" height="36"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
+                                <color key="textColor" name="primaryLabelColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T4r-Fh-6oO">
+                                <rect key="frame" x="24" y="228" width="47" height="24"/>
+                                <fontDescription key="fontDescription" type="system" weight="light" pointSize="20"/>
+                                <color key="textColor" name="secondaryLabelColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ox7-a2-qYT">
+                                <rect key="frame" x="24" y="158" width="116.5" height="55"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="46"/>
+                                <color key="textColor" name="primaryLabelColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="K3e-f7-x3z">
+                                <rect key="frame" x="24" y="221" width="51" height="26.5"/>
+                                <fontDescription key="fontDescription" type="system" weight="light" pointSize="22"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
@@ -44,15 +65,28 @@
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="ZlX-eS-Yvg" secondAttribute="bottom" id="0m3-gk-sI3"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="dmA-fx-uIw" secondAttribute="trailing" id="26A-HR-Krh"/>
+                            <constraint firstItem="dfo-Bk-tQ1" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="3rE-DE-i5j"/>
+                            <constraint firstItem="Ox7-a2-qYT" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="70" id="60B-bR-9bf"/>
                             <constraint firstItem="dmA-fx-uIw" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="8sb-a4-2KC"/>
                             <constraint firstItem="dmA-fx-uIw" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" constant="44" id="CbZ-gb-u8F"/>
+                            <constraint firstItem="K3e-f7-x3z" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="24" id="Esz-F4-FPa"/>
+                            <constraint firstItem="dfo-Bk-tQ1" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="K6n-hm-DHE"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mxw-FV-eBm" secondAttribute="trailing" symbolic="YES" id="LuX-hH-50l"/>
                             <constraint firstItem="ZlX-eS-Yvg" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="OFr-if-N9z"/>
                             <constraint firstAttribute="trailing" secondItem="ZlX-eS-Yvg" secondAttribute="trailing" id="OkY-Ki-cEN"/>
-                            <constraint firstItem="Bmu-YM-ARP" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="24" id="dzV-x8-0gt"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Ox7-a2-qYT" secondAttribute="trailing" symbolic="YES" id="PEa-7N-X4Y"/>
+                            <constraint firstItem="T4r-Fh-6oO" firstAttribute="top" secondItem="mxw-FV-eBm" secondAttribute="bottom" constant="18" id="SPr-4s-61q"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="T4r-Fh-6oO" secondAttribute="trailing" symbolic="YES" id="Zz4-tv-PeK"/>
+                            <constraint firstItem="mxw-FV-eBm" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="86" id="adg-qC-y3E"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="K3e-f7-x3z" secondAttribute="trailing" symbolic="YES" id="c71-t5-n34"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="dmA-fx-uIw" secondAttribute="bottom" id="eMu-1s-Pwo"/>
+                            <constraint firstItem="mxw-FV-eBm" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="23" id="fs5-rn-yGh"/>
+                            <constraint firstItem="Ox7-a2-qYT" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="24" id="gyY-aH-bq8"/>
                             <constraint firstItem="ZlX-eS-Yvg" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="pLj-41-9fI"/>
-                            <constraint firstItem="Bmu-YM-ARP" firstAttribute="top" secondItem="ZlX-eS-Yvg" secondAttribute="top" constant="101" id="ucC-5M-Fv0"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Bmu-YM-ARP" secondAttribute="trailing" constant="24" id="x7L-XF-hax"/>
+                            <constraint firstItem="K3e-f7-x3z" firstAttribute="top" secondItem="Ox7-a2-qYT" secondAttribute="bottom" constant="8" id="pvZ-uX-J8f"/>
+                            <constraint firstItem="T4r-Fh-6oO" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="24" id="r4q-tG-G7g"/>
+                            <constraint firstItem="dfo-Bk-tQ1" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="rfb-HK-NMr"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="dfo-Bk-tQ1" secondAttribute="trailing" id="uAV-bK-Z9c"/>
                         </constraints>
                         <connections>
                             <outletCollection property="gestureRecognizers" destination="Rh0-a6-UQZ" appends="YES" id="Td2-ul-FSI"/>
@@ -60,7 +94,11 @@
                     </view>
                     <navigationItem key="navigationItem" id="P6e-3z-28Z"/>
                     <connections>
-                        <outlet property="bottleInfoLabel" destination="Bmu-YM-ARP" id="hXu-Ok-U5l"/>
+                        <outlet property="bottleDdayLabel" destination="Ox7-a2-qYT" id="H0D-eg-8X3"/>
+                        <outlet property="bottleTitleLabel" destination="K3e-f7-x3z" id="n9O-dd-PUs"/>
+                        <outlet property="emptyBottomLabel" destination="T4r-Fh-6oO" id="kGg-6k-DRD"/>
+                        <outlet property="emptyTopLabel" destination="mxw-FV-eBm" id="p3m-Ek-xyl"/>
+                        <outlet property="homeCharacter" destination="dfo-Bk-tQ1" id="pAM-Ay-Jl4"/>
                         <outlet property="homeView" destination="8bC-Xf-vdC" id="edO-Zc-7da"/>
                         <segue destination="abG-42-vcb" kind="presentation" identifier="presentNewBottleNameField" id="aZQ-BA-T0f"/>
                         <segue destination="moi-e1-3hQ" kind="presentation" identifier="presentNewNoteDatePicker" id="5ln-YY-tck"/>
@@ -1075,6 +1113,93 @@
             </objects>
             <point key="canvasLocation" x="-2143.1999999999998" y="3922.1674876847292"/>
         </scene>
+        <!--Bottle Name Edit View Controller-->
+        <scene sceneID="MId-q3-d4e">
+            <objects>
+                <viewController storyboardIdentifier="BottleNameEditViewController" modalTransitionStyle="crossDissolve" modalPresentationStyle="overFullScreen" id="6qv-0D-QgR" customClass="BottleNameEditViewController" customModule="Happiggy_bank" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="iEM-wQ-qg3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LVr-X2-c6j">
+                                <rect key="frame" x="0.0" y="44" width="375" height="44"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <items>
+                                    <navigationItem id="bkX-Lf-cfM">
+                                        <barButtonItem key="leftBarButtonItem" title="Dismiss" image="xmark" id="7Hz-au-GCe">
+                                            <connections>
+                                                <action selector="cancelButtonDidTap:" destination="6qv-0D-QgR" id="JQe-kV-ilU"/>
+                                            </connections>
+                                        </barButtonItem>
+                                        <barButtonItem key="rightBarButtonItem" title="Next" image="checkmark" id="g6L-cN-iPt">
+                                            <color key="tintColor" name="customTint"/>
+                                            <connections>
+                                                <action selector="saveButtonDidTap:" destination="6qv-0D-QgR" id="gTv-ak-Qjt"/>
+                                            </connections>
+                                        </barButtonItem>
+                                    </navigationItem>
+                                </items>
+                            </navigationBar>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uzj-9k-jmQ">
+                                <rect key="frame" x="166.5" y="228" width="42" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="WZB-gS-L3z">
+                                <rect key="frame" x="32" y="281" width="311" height="56"/>
+                                <color key="backgroundColor" name="pickerSelectionColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="56" id="oBQ-dz-Jwo"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tc7-Vn-QzQ">
+                                <rect key="frame" x="166.5" y="353" width="42" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aUM-UH-aAZ">
+                                <rect key="frame" x="166.5" y="382" width="42" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="r2b-4v-hhO"/>
+                        <color key="backgroundColor" name="homeBackground"/>
+                        <constraints>
+                            <constraint firstItem="Tc7-Vn-QzQ" firstAttribute="top" secondItem="WZB-gS-L3z" secondAttribute="bottom" constant="16" id="7vo-KV-AV1"/>
+                            <constraint firstItem="LVr-X2-c6j" firstAttribute="leading" secondItem="r2b-4v-hhO" secondAttribute="leading" id="ACt-u1-xwz"/>
+                            <constraint firstItem="aUM-UH-aAZ" firstAttribute="centerX" secondItem="iEM-wQ-qg3" secondAttribute="centerX" id="Bin-B0-erM"/>
+                            <constraint firstItem="WZB-gS-L3z" firstAttribute="centerX" secondItem="iEM-wQ-qg3" secondAttribute="centerX" id="E7F-H1-5he"/>
+                            <constraint firstItem="LVr-X2-c6j" firstAttribute="top" secondItem="r2b-4v-hhO" secondAttribute="top" id="PxM-lv-MxH"/>
+                            <constraint firstItem="uzj-9k-jmQ" firstAttribute="top" secondItem="LVr-X2-c6j" secondAttribute="bottom" constant="140" id="Rp4-QX-Efr"/>
+                            <constraint firstItem="LVr-X2-c6j" firstAttribute="trailing" secondItem="r2b-4v-hhO" secondAttribute="trailing" id="Tc5-6e-E0d"/>
+                            <constraint firstItem="aUM-UH-aAZ" firstAttribute="top" secondItem="Tc7-Vn-QzQ" secondAttribute="bottom" constant="8" id="cWI-ro-PlC"/>
+                            <constraint firstItem="WZB-gS-L3z" firstAttribute="leading" secondItem="r2b-4v-hhO" secondAttribute="leading" constant="32" id="dC9-hC-YiC"/>
+                            <constraint firstItem="WZB-gS-L3z" firstAttribute="top" secondItem="uzj-9k-jmQ" secondAttribute="bottom" constant="32" id="f75-ZQ-d8g"/>
+                            <constraint firstItem="r2b-4v-hhO" firstAttribute="trailing" secondItem="WZB-gS-L3z" secondAttribute="trailing" constant="32" id="lFh-rP-fbp"/>
+                            <constraint firstItem="Tc7-Vn-QzQ" firstAttribute="centerX" secondItem="iEM-wQ-qg3" secondAttribute="centerX" id="zBs-kE-h6y"/>
+                            <constraint firstItem="uzj-9k-jmQ" firstAttribute="centerX" secondItem="iEM-wQ-qg3" secondAttribute="centerX" id="zls-ao-dEj"/>
+                        </constraints>
+                    </view>
+                    <size key="freeformSize" width="375" height="812"/>
+                    <connections>
+                        <outlet property="bottomLabel" destination="Tc7-Vn-QzQ" id="Rdf-7z-iF1"/>
+                        <outlet property="navigationBar" destination="LVr-X2-c6j" id="899-iN-87N"/>
+                        <outlet property="saveButton" destination="g6L-cN-iPt" id="6Oy-Sb-XZC"/>
+                        <outlet property="textField" destination="WZB-gS-L3z" id="sY3-7J-FHN"/>
+                        <outlet property="topLabel" destination="uzj-9k-jmQ" id="1uk-bl-uqC"/>
+                        <outlet property="warningLabel" destination="aUM-UH-aAZ" id="gNj-FB-e2W"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="M4E-La-x5M" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-3111" y="2432"/>
+        </scene>
     </scenes>
     <inferredMetricsTieBreakers>
         <segue reference="utJ-Hb-n6A"/>
@@ -1092,17 +1217,27 @@
         <image name="checkmark" catalog="system" width="128" height="114"/>
         <image name="chevron.right" catalog="system" width="96" height="128"/>
         <image name="homeBackgroundBlurredLight" width="375" height="812"/>
+        <image name="homeCharacter" width="375" height="812"/>
         <image name="next" width="42" height="42"/>
         <image name="xmark" catalog="system" width="128" height="113"/>
         <image name="xmark" width="42" height="42"/>
         <namedColor name="customGray">
             <color red="0.60000002384185791" green="0.60000002384185791" blue="0.60000002384185791" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <namedColor name="customTint">
+            <color red="0.082352941176470587" green="0.65098039215686276" blue="0.42352941176470588" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <namedColor name="homeBackground">
             <color red="0.94117647058823528" green="0.94117647058823528" blue="0.94117647058823528" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="pickerSelectionColor">
             <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="primaryLabelColor">
+            <color red="1" green="0.70196078431372544" blue="0.12941176470588237" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="secondaryLabelColor">
+            <color red="0.77254901960784317" green="0.71764705882352942" blue="0.61568627450980395" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="warningLabelColor">
             <color red="1" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -50,6 +50,24 @@ extension HomeViewController {
         
         /// 저금통 개봉 확인 알림 취소 버튼 제목
         static let bottleOpenAlertCancelButtonTitle = "취소"
+        
+        /// 저금통이 없는 경우 나타나는 상단 라벨 문자열
+        static let emptyTopLabelText: String = "저금통이 없습니다."
+        
+        /// 저금통이 없는 경우 나타나는 아래 라벨 문자열
+        static let emptyBottomLabelText: String = "탭해서 행복저금통을 추가해주세요."
+        
+        /// 기한이 지났는데 저금통을 열지 않은 경우 나타내는 문자열
+        static let openDatePassedMessage: String = "저금통을 개봉해주세요!"
+        
+        /// 저금통 제목 이미 바꿨을 때 나오는 알림 제목
+        static let bottleNameFixedAlertTitle = "이미 저금통 이름을 변경했습니다."
+        
+        /// 저금통 제목 이미 바꿨을 때 나오는 알림 확인 버튼 제목
+        static let bottleNameFixedAlertConfirm = "확인"
+        
+        /// BottleNameEditViewController identifier
+        static let bottleNameEditViewController = "BottleNameEditViewController"
     }
 }
 
@@ -932,6 +950,57 @@ extension NewBottleMessageFieldViewController {
         
         /// 글자수 제한
         static let textFieldMaxLength = 15
+        
+        /// 한글 글자수 제한
+        static let textFieldKoreanMaxLength = textFieldMaxLength + 1
+        
+        /// 텍스트필드 corner radius
+        static let textFieldCornerRadius: CGFloat = 10
+    }
+}
+
+extension BottleNameEditViewController {
+    
+    /// NewBottleNameFieldViewController에서 사용하는 문자열
+    enum StringLiteral {
+        
+        /// 키보드 언어 설정이 한글인 경우
+        static let korean = "ko-KR"
+        
+        /// 상단 라벨의 문자열
+        static let topLabel = "변경할 저금통 이름을 입력해주세요."
+        
+        /// 텍스트필드 플레이스홀더 문자열
+        static let placeholder = "최대 10글자까지 입력 가능합니다."
+        
+        /// 하단 라벨의 문자열
+        static let bottomLabel = "저금통 이름 변경 시, 추가 변경은 불가합니다."
+        
+        /// 이름이 없을 때 경고 라벨의 문자열
+        static let warningLabel = "저금통 이름이 없어요!"
+        
+        /// 이름이 같을 때 경고 라벨의 문자열
+        static let sameNameWarningLabel = "저금통 이름이 같아요!"
+    }
+    
+    /// NewBottleNameFieldViewController에서 사용하는 폰트 크기
+    enum FontSize {
+        
+        /// 상단 라벨 텍스트 크기
+        static let topLabelText: CGFloat = 17
+        
+        /// 하단 라벨 텍스트 크기
+        static let bottomLabelText: CGFloat = 14
+    
+        /// 경고 라벨 텍스트 색상
+        static let warningLabelText: CGFloat = 14
+    }
+    
+    /// NewBottleNameFieldViewController에서 설정하는 layout 상수값
+    enum Metric {
+        
+        /// 글자수 제한
+        static let textFieldMaxLength = 10
         
         /// 한글 글자수 제한
         static let textFieldKoreanMaxLength = textFieldMaxLength + 1

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -30,6 +30,9 @@ extension HomeViewController {
         
         /// Bottle Label의 배경 투명도
         static let bottleLabelBackgroundOpacity: CGFloat = 0.6
+        
+        /// 기한이 지났는데 저금통을 열지 않은 경우 나타내는 라벨 앞쪽 패딩
+        static let openDatePassedLabelLeadingPadding: CGFloat = 16
     }
     
     /// 애니메이션 시간
@@ -68,6 +71,13 @@ extension HomeViewController {
         
         /// BottleNameEditViewController identifier
         static let bottleNameEditViewController = "BottleNameEditViewController"
+    }
+    
+    /// 폰트 크기
+    enum FontSize {
+        
+        /// 기한이 지났는데 저금통을 열지 않은 경우 나타내는 라벨 폰트 크기
+        static let openDatePassedLabelFont: CGFloat = 15
     }
 }
 

--- a/Happiggy-bank/Happiggy-bank/ViewController/BottleNameEditViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/BottleNameEditViewController.swift
@@ -1,0 +1,224 @@
+//
+//  BottleNameEditViewController.swift
+//  Happiggy-bank
+//
+//  Created by Eunbin Kwon on 2022/04/08.
+//
+
+import UIKit
+
+import Then
+
+/// 새 유리병 이름 입력하는 뷰 컨트롤러
+final class BottleNameEditViewController: UIViewController {
+    
+    // MARK: Properties
+    
+    /// 내비게이션 바
+    @IBOutlet weak var navigationBar: UINavigationBar!
+    
+    /// 다음 화면으로 넘어가는 바 버튼
+    @IBOutlet weak var saveButton: UIBarButtonItem!
+    
+    /// 상단 라벨
+    @IBOutlet weak var topLabel: UILabel!
+    
+    /// 텍스트필드
+    @IBOutlet weak var textField: UITextField!
+    
+    /// 하단 라벨
+    @IBOutlet weak var bottomLabel: UILabel!
+    
+    /// 이름이 없을 때 표시되는 경고 라벨
+    @IBOutlet weak var warningLabel: UILabel!
+    
+    /// 유리병 데이터
+    var bottle: Bottle!
+    
+    /// 경고 라벨 보여줄지 안보여줄지 설정하는 불리언 값
+    private var showWarningLabel: Bool = false
+    
+    
+    // MARK: Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        initializeTextField()
+        initializeLabels()
+        makeNavigationBarClear()
+    }
+    
+    
+    // MARK: IBAction
+    
+    /// 취소 버튼을 눌렀을 때 실행되는 액션
+    @IBAction func cancelButtonDidTap(_ sender: UIBarButtonItem) {
+        self.fadeOut()
+        self.dismiss(animated: false)
+    }
+    
+    /// 변경된 내용 저장
+    @IBAction func saveButtonDidTap(_ sender: UIBarButtonItem) {
+        guard let text = self.textField.text
+        else { return }
+        
+        if text.isEmpty {
+            HapticManager.instance.notification(type: .error)
+            self.showWarningLabel = true
+            self.warningLabel.text = StringLiteral.warningLabel
+            self.warningLabel.fadeIn()
+            return
+        }
+        
+        if text == self.bottle.title {
+            HapticManager.instance.notification(type: .error)
+            self.showWarningLabel = true
+            self.warningLabel.text = StringLiteral.sameNameWarningLabel
+            self.warningLabel.fadeIn()
+            return
+        }
+        
+        self.bottle.title = text
+//        PersistenceStore.shared.save()
+        self.dismiss(animated: true)
+    }
+    
+    /// 텍스트필드 내용이 변경됐을 때 호출되는 함수
+    /// 텍스트필드의 텍스트가 있는지 없는지 판별
+    @objc func textFieldDidChange(_ textField: UITextField) {
+        guard let text = textField.text
+        else { return }
+
+        if text.isEmpty {
+            self.showWarningLabel = true
+            self.warningLabel.text = StringLiteral.warningLabel
+            self.warningLabel.isHidden = false
+            self.warningLabel.fadeIn()
+            return
+        }
+        
+        if text == bottle.title {
+            self.showWarningLabel = true
+            self.warningLabel.text = StringLiteral.sameNameWarningLabel
+            self.warningLabel.isHidden = false
+            self.warningLabel.fadeIn()
+            return
+        }
+        
+        self.showWarningLabel = false
+        self.warningLabel.fadeOut()
+    }
+    
+    
+    // MARK: View Configuration
+    
+    /// 내비게이션 바 투명하게 만드는 함수
+    private func makeNavigationBarClear() {
+        self.navigationBar.setBackgroundImage(UIImage(), for: .default)
+        self.navigationBar.shadowImage = UIImage()
+    }
+    
+    /// 텍스트필드 초기 세팅
+    private func initializeTextField() {
+        self.textField.attributedPlaceholder = NSMutableAttributedString(
+            string: StringLiteral.placeholder
+        ).color(
+            targetString: StringLiteral.placeholder,
+            color: .customPlaceholderText
+        )
+        self.textField.text = self.bottle.title
+        self.textField.layer.cornerRadius = Metric.textFieldCornerRadius
+        self.textField.delegate = self
+        self.textField.becomeFirstResponder()
+        self.textField.addTarget(
+            self,
+            action: #selector(self.textFieldDidChange(_:)),
+            for: .editingChanged
+        )
+    }
+    
+    /// 라벨 초기 세팅
+    private func initializeLabels() {
+        // top label
+        self.topLabel.text = StringLiteral.topLabel
+        self.topLabel.font = .systemFont(ofSize: FontSize.topLabelText)
+        self.topLabel.textColor = .customLabel
+        
+        // bottom label
+        self.bottomLabel.text = StringLiteral.bottomLabel
+        self.bottomLabel.font = .systemFont(ofSize: FontSize.bottomLabelText)
+        self.bottomLabel.textColor = .customSecondaryLabel
+        
+        // warning label
+        self.warningLabel.text = StringLiteral.warningLabel
+        self.warningLabel.font = .systemFont(ofSize: FontSize.warningLabelText)
+        self.warningLabel.textColor = .customWarningLabel
+        self.warningLabel.isHidden = true
+    }
+}
+
+extension BottleNameEditViewController: UITextFieldDelegate {
+    
+    /// 리턴 키를 눌렀을 때 자동으로 다음 뷰로 넘어가며, 텍스트필드의 firstResponder 해제
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        guard let text = self.textField.text
+        else { return self.textField.resignFirstResponder() }
+
+        if text.isEmpty {
+            HapticManager.instance.notification(type: .warning)
+            self.showWarningLabel = true
+            self.warningLabel.text = StringLiteral.warningLabel
+            self.warningLabel.fadeIn()
+            return self.textField.resignFirstResponder()
+        }
+        
+        if text == self.bottle.title {
+            HapticManager.instance.notification(type: .warning)
+            self.showWarningLabel = true
+            self.warningLabel.text = StringLiteral.sameNameWarningLabel
+            self.warningLabel.fadeIn()
+            return self.textField.resignFirstResponder()
+        }
+        
+        self.performSegue(
+            withIdentifier: SegueIdentifier.presentNewBottleDatePicker,
+            sender: nil
+        )
+        
+        return self.textField.resignFirstResponder()
+    }
+    
+    /// 최대 글자수 10자 제한
+    func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        guard let text = self.textField.text,
+              let textRange = Range(range, in: text)
+        else { return false }
+        
+        let maxLength = self.textField.textInputMode?.primaryLanguage == StringLiteral.korean ?
+        Metric.textFieldKoreanMaxLength :
+        Metric.textFieldMaxLength
+        
+        var updatedText = text.replacingCharacters(in: textRange, with: string)
+        
+        if updatedText.count > maxLength {
+            guard let overflow = Range(
+                NSRange(
+                    location: Metric.textFieldMaxLength,
+                    length: updatedText.count - Metric.textFieldMaxLength
+                ),
+                in: updatedText
+            )
+            else { return false }
+            
+            updatedText.removeSubrange(overflow)
+            self.textField.text = updatedText
+            return false
+        }
+        
+        return true
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/ViewController/HomeViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/HomeViewController.swift
@@ -220,7 +220,22 @@ final class HomeViewController: UIViewController {
                 return
             }
             if self.viewModel.isEndDatePassed {
-                self.bottleDdayLabel.text = StringLiteral.openDatePassedMessage
+                let openDatePassedLabel = UILabel().then {
+                    $0.text = StringLiteral.openDatePassedMessage
+                    $0.font = .systemFont(ofSize: FontSize.openDatePassedLabelFont)
+                    $0.textColor = .customWarningLabel
+                    $0.translatesAutoresizingMaskIntoConstraints = false
+                }
+                self.view.addSubview(openDatePassedLabel)
+                NSLayoutConstraint.activate([
+                    openDatePassedLabel.centerYAnchor.constraint(
+                        equalTo: self.bottleDdayLabel.centerYAnchor
+                    ),
+                    openDatePassedLabel.leadingAnchor.constraint(
+                        equalTo: self.bottleDdayLabel.trailingAnchor,
+                        constant: Metric.openDatePassedLabelLeadingPadding
+                    )
+                ])
                 return
             }
         } else {

--- a/Happiggy-bank/Happiggy-bank/ViewModel/HomeViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/HomeViewModel.swift
@@ -19,6 +19,30 @@ final class HomeViewModel {
         self.bottle != nil
     }
     
+    /// 오늘이 개봉날인지 아닌지에 대한 불리언 값
+    var isTodayEndDate: Bool {
+        let today = Calendar.current.startOfDay(for: Date()).customFormatted(type: .dot)
+        let endDate = self.bottle?.endDate.customFormatted(type: .dot)
+        
+        return today == endDate
+    }
+    
+    /// 개봉날이 지났는지 아닌지에 대한 불리언 값
+    var isEndDatePassed: Bool {
+        let today = Calendar.current.startOfDay(for: Date())
+        guard let endDate = self.bottle?.endDate
+        else { return false }
+        
+        return today > endDate
+    }
+    
+    /// 제목 수정했는지 아닌지에 대한 불리언 값
+    var hasFixedTitle: Bool {
+        guard let hasFixed = self.bottle?.hasFixedTitle
+        else { return false }
+        return hasFixed
+    }
+    
     
     // MARK: - init
     init() {
@@ -56,5 +80,21 @@ final class HomeViewModel {
         
 //        self.bottle = Bottle.foo
 //        self.bottle = Bottle.fullBottle
+    }
+
+    func dDay() -> String {
+        guard let endDate = bottle?.endDate
+        else { return "" }
+        let prefix = "D-"
+        let startDate = Date()
+        let daysCount = Calendar.current.dateComponents(
+            [.day],
+            from: endDate,
+            to: startDate
+        )
+        guard let days = daysCount.day
+        else { return "" }
+        
+        return prefix + "\(-1 * days)"
     }
 }

--- a/Happiggy-bank/Happiggy-bank/ViewModel/HomeViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/HomeViewModel.swift
@@ -78,7 +78,7 @@ final class HomeViewModel {
 //
         self.bottle = bottles.first
         
-//        self.bottle = Bottle.foo
+        self.bottle = Bottle.foo
 //        self.bottle = Bottle.fullBottle
     }
 


### PR DESCRIPTION
### 반영 내용
issue #63, #81, #123

### BottleNameEditViewController
- 저금통 이름 수정 화면
- 저금통 이름이 없거나 같으면 저장 불가

### HomeViewController
- 저금통이 없을 때, 있을 때 화면 요소 변경
- 저금통 이름 라벨을 눌렀을 때 저금통 이름 수정 화면으로 이동

### 변경사항 저장 후 홈 화면으로 돌아왔을 때 데이터 변경되는 로직 추가/확인 필요