### PR TITLE
[feat] 저금통 개봉 시 현재 모습 스냅샷 저장 #114 

### DIFF
--- a/Happiggy-bank/Happiggy-bank/CoreData/Bottle+CoreDataClass.swift
+++ b/Happiggy-bank/Happiggy-bank/CoreData/Bottle+CoreDataClass.swift
@@ -193,7 +193,7 @@ extension Bottle {
     
     /// 테스트용 목 데이터
     static let foo: Bottle = {
-        let offset = 3
+        let offset = 0
         let count = 365 - offset
         let startDate = nthDayFromToday(-count)
         let endDate = nthDayFromToday(-1 + offset)
@@ -206,13 +206,6 @@ extension Bottle {
                 content: "일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십",
                 bottle: bottle)
         }
-//        Note.create(date: startDate, color: NoteColor.green, content: "시작!", bottle: bottle)
-//        Note.create(date: nthDayFromToday(-9), color: NoteColor.pink, content: "일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십", bottle: bottle)
-//        Note.create(date: nthDayFromToday(-3), color: NoteColor.white, content: "100자 좀 적은가? 근데 괜찮은 것 같기도 하고...늘리기는 또 귀찮은데...", bottle: bottle)
-//        Note.create(date: nthDayFromToday(-8), color: NoteColor.purple, content: "왜냐면 한줄만 쓰는 날도 백퍼 있을 것이기 때문", bottle: bottle)
-//        Note.create(date: nthDayFromToday(-1), color: NoteColor.yellow, content: "졸리다 졸려 졸려", bottle: bottle)
-        // MARK: - 오늘 이미 작성한 상태 테스트하려면 아래 주석 해제
-//        Note.create(date: Date(), color: NoteColor.yellow, content: "누가 뚝딱 만들어주면 좋겠다 한 3줄 정도까지 채우고 싶은데 아무거나 써보기 이모지도 써보기 시험 시험 테스트 ☀️", bottle: bottle)
         
         return bottle
     }()

--- a/Happiggy-bank/Happiggy-bank/CoreData/Bottle+CoreDataClass.swift
+++ b/Happiggy-bank/Happiggy-bank/CoreData/Bottle+CoreDataClass.swift
@@ -7,7 +7,7 @@
 //
 
 import CoreData
-import Foundation
+import UIKit
 
 import Then
 
@@ -64,7 +64,7 @@ public class Bottle: NSManagedObject {
     }
     
     
-    // MARK: - (nil-coalesced) Properties
+    // MARK: - Nil-coalesced Attributes
     
     /// 고유 아이디
     public var id: UUID { id_ ?? UUID() }
@@ -90,6 +90,12 @@ public class Bottle: NSManagedObject {
         message_ ?? .empty
     }
     
+    /// 이미지
+    var image: UIImage {
+        get { UIImage(data: image_ ?? Data()) ?? UIImage() }
+        set { image_ = newValue.jpegData(compressionQuality: .one) }
+    }
+    
     /// 해당 저금통에 들어있는 쪽지들의 배열
     var notes: [Note] {
         guard let notes = self.notes_ as? Set<Note>
@@ -97,6 +103,9 @@ public class Bottle: NSManagedObject {
         
         return notes.map { $0 }.sorted { $0.date < $1.date }
     }
+
+    
+    // MARK: - Properties
     
     // TODO: 유저가 앱을 켜놓은 상태에서 기한이 지나면?
     /// 저금통이 진행 중인지 혹은 종료 후 미개봉 상태인지 나타냄

--- a/Happiggy-bank/Happiggy-bank/Happiggy-bank.xcdatamodeld/Happigy-bank.xcdatamodel/contents
+++ b/Happiggy-bank/Happiggy-bank/Happiggy-bank.xcdatamodeld/Happigy-bank.xcdatamodel/contents
@@ -4,10 +4,11 @@
         <attribute name="endDate_" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="hasFixedTitle" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="id_" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="image_" optional="YES" attributeType="Binary"/>
         <attribute name="isOpen" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="message_" attributeType="String" minValueString="1" maxValueString="15"/>
         <attribute name="startDate_" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="title_" attributeType="String"/>
+        <attribute name="title_" attributeType="String" minValueString="1" maxValueString="10"/>
         <relationship name="notes_" optional="YES" toMany="YES" maxCount="365" deletionRule="Cascade" destinationEntity="Note" inverseName="bottle_" inverseEntity="Note"/>
     </entity>
     <entity name="Note" representedClassName="Note" syncable="YES" codeGenerationType="category">
@@ -18,7 +19,7 @@
         <relationship name="bottle_" maxCount="1" deletionRule="Nullify" destinationEntity="Bottle" inverseName="notes_" inverseEntity="Bottle"/>
     </entity>
     <elements>
-        <element name="Bottle" positionX="170.34765625" positionY="-325.72265625" width="128" height="149"/>
+        <element name="Bottle" positionX="170.34765625" positionY="-325.72265625" width="128" height="164"/>
         <element name="Note" positionX="179.48046875" positionY="-52.40625" width="128" height="104"/>
     </elements>
 </model>

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -48,6 +48,9 @@ extension HomeViewController {
         /// 저금통 개봉 확인 알림 제목
         static let bottleOpenAlertTitle = "저금통 개봉날이에요! 개봉하시겠어요?"
         
+        ///
+        static let bottleOpenAlertMessage = "현재 저금통 모습이 그대로 저장됩니다"
+        
         /// 저금통 개봉 확인 알림 개봉 버튼 제목
         static let bottleOpenAlertOpenButtonTitle = "개봉"
         

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -1036,3 +1036,23 @@ extension CustomTabBar {
         )
     }
 }
+
+extension HomeViewModel {
+    
+    /// 상수값
+    enum Metric {
+        
+        /// 저금통 스냅샷 사이즈
+        static func snapshotSize(forView containerView: UIView) -> CGSize {
+            let bottleListWidth = UIScreen.main.bounds.width
+            let snapshotWidth = (bottleListWidth - 3 * interSnapshotSpacingInBottleList) / 2
+            let scale = snapshotWidth / containerView.frame.width
+            let snapShotheight = containerView.frame.height * scale
+            
+            return CGSize(width: snapshotWidth, height: snapShotheight)
+        }
+        
+        /// 저금통 리스트에서 스냅샷 간 간격
+        private static let interSnapshotSpacingInBottleList: CGFloat = 24
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/ViewController/BottleViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/BottleViewController.swift
@@ -130,11 +130,19 @@ final class BottleViewController: UIViewController {
         
     }
     
+    /// 개봉 확인 알림이 떴을 때 호출되는 메서드
+    func bottleOpenConfirmationAlertDidAppear() {
+        self.gravity?.disable()
+    }
+    
+    /// 개봉 취소를 눌렀을 때 호출되는 메서드
+    func bottleDidNotOpen() {
+        self.gravity?.enable()
+    }
+
     /// 저금통 개봉 시 호출되는 메서드
     /// 중력 해제, 저금통 nil 처리, 쪽지 노드 제거
-    func bottleIsOpened(withDuration duration: TimeInterval) {
-
-        self.gravity?.disable()
+    func bottleDidOpen(withDuration duration: TimeInterval) {
         self.gravity = nil
         self.viewModel.bottle = nil
         UIView.transition(

--- a/Happiggy-bank/Happiggy-bank/ViewController/HomeViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/HomeViewController.swift
@@ -278,7 +278,7 @@ final class HomeViewController: UIViewController {
     
     /// 저금통 개봉 의사를 물어보는 알림을 띄움
     private func presentBottleOpenConfirmationAlert() {
-        let alert = makeBottleOpenConfirmationAlert()
+        let alert = self.makeBottleOpenConfirmationAlert()
         self.present(alert, animated: true)
     }
     
@@ -286,7 +286,7 @@ final class HomeViewController: UIViewController {
     private func makeBottleOpenConfirmationAlert() -> UIAlertController {
         let alert = UIAlertController(
             title: StringLiteral.bottleOpenAlertTitle,
-            message: nil,
+            message:StringLiteral.bottleOpenAlertMessage,
             preferredStyle: .alert
         )
         

--- a/Happiggy-bank/Happiggy-bank/ViewController/HomeViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/HomeViewController.swift
@@ -15,7 +15,7 @@ final class HomeViewController: UIViewController {
     
     /// HomeViewController의 뷰
     @IBOutlet var homeView: UIView!
-
+    
     /// 저금통이 비었을 때 나타나는 배경 캐릭터
     @IBOutlet weak var homeCharacter: UIImageView!
     
@@ -81,6 +81,7 @@ final class HomeViewController: UIViewController {
         }
         if !bottle.isInProgress {
             self.presentBottleOpenConfirmationAlert()
+            self.bottleViewController.bottleOpenConfirmationAlertDidAppear()
             return
         }
         if !bottle.hasEmptyDate {
@@ -103,7 +104,7 @@ final class HomeViewController: UIViewController {
         }
     }
     
-    // FIXME: - sender 인식 안되므로 제거 필요, bottleViewController 의 unwindCallDidArrive 도 수정 필요 
+    // FIXME: - sender 인식 안되므로 제거 필요, bottleViewController 의 unwindCallDidArrive 도 수정 필요
     /// 홈 뷰로 언와인드할 떄 호출되는 액션 메서드
     @IBAction func unwindCallToHomeViewDidArrive(segue: UIStoryboardSegue, sender: Any? = nil) {
         
@@ -293,13 +294,15 @@ final class HomeViewController: UIViewController {
             title: StringLiteral.bottleOpenAlertOpenButtonTitle,
             style: .default
         ) { _ in
-            self.openBottle()
+            self.bottleDidOpen()
         }
         
         let cancelAction = UIAlertAction(
             title: StringLiteral.bottleOpenAlertCancelButtonTitle,
             style: .cancel
-        )
+        ) { _ in
+            self.bottleViewController.bottleDidNotOpen()
+        }
         
         alert.addAction(openAction)
         alert.addAction(cancelAction)
@@ -331,13 +334,13 @@ final class HomeViewController: UIViewController {
     }
     
     /// 저금통 개봉
-    private func openBottle() {
+    private func bottleDidOpen() {
         guard let bottle = self.viewModel.bottle
         else { return }
         
-        bottle.isOpen.toggle()
+        self.viewModel.saveOpenedBottle(inContainerView: self.bottleViewController.view, bottle)
         HapticManager.instance.notification(type: .success)
-        self.bottleViewController.bottleIsOpened(withDuration: Duration.bottleOpeningAnimation)
+        self.bottleViewController.bottleDidOpen(withDuration: Duration.bottleOpeningAnimation)
         self.performSegue(
             withIdentifier: SegueIdentifier.presentBottleMessageView,
             sender: self

--- a/Happiggy-bank/Happiggy-bank/ViewModel/HomeViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/HomeViewModel.swift
@@ -97,4 +97,32 @@ final class HomeViewModel {
         
         return prefix + "\(-1 * days)"
     }
+    
+    /// 개봉된 저금통 상태 업데이트 후 저장
+    func saveOpenedBottle(inContainerView containerView: UIView, _ bottle: Bottle) {
+        // TODO: 개봉 처리 시점 상의
+        bottle.isOpen.toggle()
+        bottle.image = self.takeBottleSnapshot(inContainerView: containerView)
+        PersistenceStore.shared.save()
+    }
+    
+    /// 저금통의 현재 상태 스냅샷 생성
+    private func takeBottleSnapshot(inContainerView containerView: UIView) -> UIImage {
+        
+        let snapshotSize = Metric.snapshotSize(forView: containerView)
+        
+        /// 이미지 생성
+        let renderer = UIGraphicsImageRenderer(size: containerView.bounds.size)
+        let image = renderer.image { _ in
+            containerView.drawHierarchy(in: containerView.bounds, afterScreenUpdates: true)
+        }
+        
+        /// 리사이징
+        let resizedImageRenderer = UIGraphicsImageRenderer(size: snapshotSize)
+        let resizedImage = resizedImageRenderer.image { _ in
+            image.draw(in: CGRect(origin: .zero, size: snapshotSize))
+        }
+        
+        return resizedImage
+    }
 }


### PR DESCRIPTION
## 반영 내용
- 이슈 #114 

<br>

- 저금통 코어데이터 모델에 이미지 어트리뷰트를 추가했습니다. 
  - 모델 변경하는 김에 코어데이터 모델에서 저금통 제목 제한을 기존 15자 -> 10자로 변경했습니다 
- 저금통 리스트에서 보여줄 개봉 직전 저금통 상태의 스냅샷을 찍는 메서드를 구현했습니다. 
  - 굳이 아래로 쪽지 노드들을 내려보내지 않고 **현재 상태 그대로 캡쳐**되도록 했습니다
    - 대신 알림에 현재 모습이 그대로 저장된다는 안내 문구를 넣었습니다
  - 용량을 줄이기 위해 컬렉션뷰 셀 크기에 맞춰 리사이징했습니다. 
    - 다만 자동으로 소수점이 반올림되는 것 같아서 이 부분은 나중에 셀에 이미지 넣을 때 다시 확인해야할 것 같습니다...! 
  - 데이터 관련 내용이라고 생각해서 뷰모델에 해당 메서드를 구현했습니당
  - isOpen 을 현재는 홈뷰에서 저장 버튼을 누르는 시점에 처리하도록 했는데 **개봉 처리 시점**에 대해 같이 얘기해보면 좋을 것 같습니다. 