### PR TITLE
[feat] 저금통 개봉 애니메이션 수정 #128 

### DIFF
--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		A459003C27E9C5C9003010A0 /* CGSize+Area.swift in Sources */ = {isa = PBXBuildFile; fileRef = A459003B27E9C5C9003010A0 /* CGSize+Area.swift */; };
 		A467B5C827DA258700AC702D /* NewNoteDatePickerRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A467B5C727DA258700AC702D /* NewNoteDatePickerRowView.swift */; };
 		A467B5CA27DA289600AC702D /* NewNoteDatePickerRowView.xib in Resources */ = {isa = PBXBuildFile; fileRef = A467B5C927DA289500AC702D /* NewNoteDatePickerRowView.xib */; };
+		A46BC1EF2800626A00C2E5B4 /* TabItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A46BC1EE2800626A00C2E5B4 /* TabItem.swift */; };
 		A48E183A27E71D9300B44477 /* UILabel+ParagraphStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A48E183927E71D9300B44477 /* UILabel+ParagraphStyle.swift */; };
 		A48E183C27E7379100B44477 /* CapsuleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A48E183B27E7379100B44477 /* CapsuleButton.swift */; };
 		A48E183E27E737B600B44477 /* CapsuleButton.xib in Resources */ = {isa = PBXBuildFile; fileRef = A48E183D27E737B600B44477 /* CapsuleButton.xib */; };
@@ -120,6 +121,7 @@
 		A459003B27E9C5C9003010A0 /* CGSize+Area.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGSize+Area.swift"; sourceTree = "<group>"; };
 		A467B5C727DA258700AC702D /* NewNoteDatePickerRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNoteDatePickerRowView.swift; sourceTree = "<group>"; };
 		A467B5C927DA289500AC702D /* NewNoteDatePickerRowView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NewNoteDatePickerRowView.xib; sourceTree = "<group>"; };
+		A46BC1EE2800626A00C2E5B4 /* TabItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabItem.swift; sourceTree = "<group>"; };
 		A48E183927E71D9300B44477 /* UILabel+ParagraphStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+ParagraphStyle.swift"; sourceTree = "<group>"; };
 		A48E183B27E7379100B44477 /* CapsuleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapsuleButton.swift; sourceTree = "<group>"; };
 		A48E183D27E737B600B44477 /* CapsuleButton.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CapsuleButton.xib; sourceTree = "<group>"; };
@@ -232,6 +234,7 @@
 			children = (
 				A4F5714627DA467900E7DF9B /* DateFormat.swift */,
 				A4F5715727DC459B00E7DF9B /* NoteColor.swift */,
+				A46BC1EE2800626A00C2E5B4 /* TabItem.swift */,
 			);
 			path = Enum;
 			sourceTree = "<group>";
@@ -532,6 +535,7 @@
 				D236DB8627FDC43200D7B8F0 /* NewBottleDatePickerViewModel.swift in Sources */,
 				A499318327BF5158009FF5A8 /* BottleNoteView.swift in Sources */,
 				A4CF2C8E27CBA49D001B01B1 /* UIViewController+NotificationCenter.swift in Sources */,
+				A46BC1EF2800626A00C2E5B4 /* TabItem.swift in Sources */,
 				D284A5DE27FF3EFB00D20699 /* BottleNameEditViewController.swift in Sources */,
 				A8BD834D27BE39D600E0DE41 /* NoteProgressLabel.swift in Sources */,
 				A8509E6E27C89A1200855153 /* UIColor+Extension.swift in Sources */,

--- a/Happiggy-bank/Happiggy-bank/Enum/TabItem.swift
+++ b/Happiggy-bank/Happiggy-bank/Enum/TabItem.swift
@@ -1,0 +1,21 @@
+//
+//  TabItem.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/04/08.
+//
+
+import Foundation
+
+/// 탭 아이템
+enum TabItem: Int {
+    
+    /// 홈
+    case home
+    
+    /// 저금통 리스트
+    case bottleList
+    
+    /// 환경설정
+    case settings
+}

--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -16,11 +16,11 @@
             <objects>
                 <viewController modalTransitionStyle="crossDissolve" id="BYZ-38-t0r" customClass="HomeViewController" customModule="Happiggy_bank" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="729"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="813"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ZlX-eS-Yvg">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="729"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="813"/>
                             </imageView>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dmA-fx-uIw">
                                 <rect key="frame" x="0.0" y="44" width="414" height="769"/>
@@ -29,7 +29,7 @@
                                 </connections>
                             </containerView>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="homeCharacter" translatesAutoresizingMaskIntoConstraints="NO" id="dfo-Bk-tQ1">
-                                <rect key="frame" x="0.0" y="241" width="414" height="414"/>
+                                <rect key="frame" x="0.0" y="199.5" width="414" height="414"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="dfo-Bk-tQ1" secondAttribute="height" multiplier="1:1" id="ukt-oa-FWq"/>
                                 </constraints>
@@ -198,7 +198,6 @@
                         <outlet property="bottleTitleLabel" destination="the-XF-3HV" id="YPn-AN-tQQ"/>
                         <outlet property="tapGestureRecognizer" destination="V02-Pn-vzk" id="qFC-7m-mMh"/>
                         <outlet property="tapToContinueLabel" destination="3XN-7E-k3f" id="h8L-m8-UT6"/>
-                        <segue destination="VgM-hx-cQh" kind="unwind" identifier="unwindFromBottleMessageViewToBottleList" animates="NO" unwindAction="unwindCallToBottleListDidArriveWithSegue:" id="PtS-F8-xFo"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Vrr-k0-xCf" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -213,9 +212,9 @@
         <!--Bottle List View Controller-->
         <scene sceneID="U6G-8e-yzH">
             <objects>
-                <viewController id="E5t-46-ohL" customClass="BottleListViewController" customModule="Happiggy_bank" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="BottleListViewController" id="E5t-46-ohL" customClass="BottleListViewController" customModule="Happiggy_bank" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="nEt-Kx-IF1">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="729"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="813"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="l7q-sD-9EX">
@@ -259,16 +258,15 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="8wb-hW-wCd" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-                <exit id="VgM-hx-cQh" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="892" y="1642.6108374384237"/>
         </scene>
         <!--Note List View Controller-->
         <scene sceneID="jaT-d5-7R3">
             <objects>
-                <viewController hidesBottomBarWhenPushed="YES" id="KE3-2Z-kiH" customClass="NoteListViewController" customModule="Happiggy_bank" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="NoteListViewController" hidesBottomBarWhenPushed="YES" id="KE3-2Z-kiH" customClass="NoteListViewController" customModule="Happiggy_bank" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="96q-VD-T5D">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="729"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="813"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="SCP-Hp-DbX">
@@ -870,11 +868,11 @@
             <objects>
                 <viewController id="8AM-Vb-C6f" customClass="NoteDetailViewController" customModule="Happiggy_bank" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="XRY-6G-qf4">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="729"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="813"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="YA1-XK-Qra">
-                                <rect key="frame" x="0.0" y="114.66666666666669" width="375" height="500.00000000000006"/>
+                                <rect key="frame" x="0.0" y="156.5" width="414" height="500"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="500" id="J04-tK-UsO"/>
@@ -911,14 +909,14 @@
                                 <rect key="frame" x="334" y="724" width="40" height="40"/>
                             </imageView>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="characterPink" translatesAutoresizingMaskIntoConstraints="NO" id="OBm-7g-O6d">
-                                <rect key="frame" x="167.66666666666666" y="44.666666666666657" width="40" height="40"/>
+                                <rect key="frame" x="187" y="86.5" width="40" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="OBm-7g-O6d" secondAttribute="height" multiplier="1:1" id="fIe-eg-1p2"/>
                                     <constraint firstAttribute="width" constant="40" id="oo5-Lf-6Jb"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nqC-5b-cQf">
-                                <rect key="frame" x="167.66666666666666" y="650.66666666666663" width="40" height="20"/>
+                                <rect key="frame" x="187" y="692.5" width="40" height="20"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <color key="textColor" name="secondaryLabelColor"/>
                                 <nil key="highlightedColor"/>
@@ -1214,23 +1212,23 @@
         <segue reference="7wk-af-F5w"/>
     </inferredMetricsTieBreakers>
     <resources>
-        <image name="back" width="42" height="42"/>
+        <image name="back" width="10" height="18"/>
         <image name="bottleMessageCharacter" width="375" height="812"/>
         <image name="characterGreen" width="40" height="40"/>
         <image name="characterPink" width="40" height="40"/>
         <image name="characterPurple" width="40" height="40"/>
         <image name="characterWhite" width="40" height="40"/>
         <image name="characterYellow" width="40" height="40"/>
-        <image name="checkmark" width="42" height="42"/>
+        <image name="checkmark" width="19" height="16"/>
         <image name="homeCharacter" width="375" height="812"/>
-        <image name="next" width="42" height="42"/>
+        <image name="next" width="10" height="18"/>
         <image name="tabBarHomeNormal" width="36" height="26"/>
         <image name="tabBarHomeSelected" width="36" height="26"/>
         <image name="tabBarListNormal" width="36" height="26"/>
         <image name="tabBarListSelected" width="36" height="26"/>
         <image name="tabBarSettingsNormal" width="36" height="26"/>
         <image name="tabBarSettingsSelected" width="36" height="26"/>
-        <image name="xmark" width="42" height="42"/>
+        <image name="xmark" width="17" height="17"/>
         <namedColor name="customGray">
             <color red="0.59999999999999998" green="0.59999999999999998" blue="0.59999999999999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -344,9 +344,6 @@ enum SegueIdentifier {
     /// 홈뷰컨트롤러에서 저금통 개봉 시 저금통 메시지 뷰 컨트롤러를 띄울 때 사용
     static let presentBottleMessageView = "presentBottleMessageView"
     
-    /// 저금통 개봉 시 저금통 메시지 뷰에서 저금통 리스트로 전환할 때 사용
-    static let unwindFromBottleMessageViewToBottleList = "unwindFromBottleMessageViewToBottleList"
-    
     /// 저금통 개봉 시점 피커 뷰에서 저금통 개봉시 멘트 필드 뷰로 전환할 때 사용
     static let presentNewBottleMessageField = "presentNewBottleMessageFieldFromDatePicker"
     
@@ -1059,3 +1056,6 @@ extension HomeViewModel {
         private static let interSnapshotSpacingInBottleList: CGFloat = 24
     }
 }
+
+/// 메인 스토리보드 이름 "main"
+let mainStoryboardName = "Main"

--- a/Happiggy-bank/Happiggy-bank/ViewController/BottleListViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/BottleListViewController.swift
@@ -37,33 +37,6 @@ final class BottleListViewController: UIViewController {
         configureEmptyLabel()
         registerBottleCell()
         layoutCells()
-        scrollToOpenBottleIfNeeded()
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-
-        guard let bottle =  self.viewModel.openingBottle
-        else {
-            self.showAllSubviews()
-            self.configureEmptyLabel()
-            return
-        }
-        self.hideAllSubviewsIfIsOpeningBottle(bottle)
-        self.scrollToOpenBottleIfNeeded()
-        self.performSegue(withIdentifier: SegueIdentifier.showNoteList, sender: bottle)
-    }
-    
-    
-    // MARK: - @IBActions
-    
-    /// 해당 뷰 컨트롤러로 언와인드 되었을 때 호출
-    @IBAction func unwindCallToBottleListDidArrive(segue: UIStoryboardSegue) {
-        guard let bottle = self.viewModel.openingBottle,
-              self.viewIfLoaded == nil
-        else { return }
-        
-        self.performSegue(withIdentifier: SegueIdentifier.showNoteList, sender: bottle)
     }
     
     
@@ -77,11 +50,9 @@ final class BottleListViewController: UIViewController {
             
             let viewModel = NoteListViewModel(
                 bottle: bottle,
-                fadeIn: self.viewModel.openingBottle != nil,
                 fetchedResultContollerDelegate: noteListViewController
             )
             noteListViewController.viewModel = viewModel
-            self.viewModel.openingBottle = nil
         }
     }
     
@@ -121,38 +92,6 @@ final class BottleListViewController: UIViewController {
     
     
     // MARK: - Functions
-    
-    /// 현재 개봉중인 저금통이 있으면 해당 저금통의 위치로 스크롤
-    private func scrollToOpenBottleIfNeeded() {
-
-        guard let indexPath = self.viewModel.openingBottleIndexPath
-        else { return }
-
-        self.collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: false)
-        self.viewModel.openingBottleIndexPath = nil
-    }
-    
-    /// 네비게이션 바, 탭바와 모든 하위 뷰를 다시 나타냄
-    private func showAllSubviews() {
-        self.title = viewModel.bottleList.isEmpty ?
-        StringLiteral.emptyListNavigationBarTitle :
-        StringLiteral.fullListNavigationBarTitle
-        
-        self.view.subviews.forEach {
-            $0.isHidden = false
-        }
-        
-        self.tabBarController?.tabBar.isHidden = false
-    }
-    
-    /// 네비게이션 바, 탭바와 모든 하위 뷰를 숨김
-    private func hideAllSubviewsIfIsOpeningBottle(_ bottle: Bottle) {
-        self.view.subviews.forEach {
-            $0.isHidden = true
-        }
-        self.tabBarController?.tabBar.isHidden = true
-        self.navigationItem.title = .empty
-    }
     
     /// 셀에 대한 레이아웃 설정하는 함수
     private func layoutCells() {

--- a/Happiggy-bank/Happiggy-bank/ViewController/HomeViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/HomeViewController.swift
@@ -192,6 +192,7 @@ final class HomeViewController: UIViewController {
             
             bottleMessageController.bottle = bottle
             bottleMessageController.fadeInOutduration = Duration.bottleOpeningAnimation
+            bottleMessageController.mainTabBarController = self.tabBarController
         }
     }
     

--- a/Happiggy-bank/Happiggy-bank/ViewModel/BottleListViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/BottleListViewModel.swift
@@ -14,20 +14,6 @@ final class BottleListViewModel {
     /// 지난 저금통 리스트
     var bottleList: [Bottle]!
     
-
-    /// 현재 열고 있는 저금통을 나타내는 프로퍼티로 있다면 해당 저금통 엔티티, 없으면 nil
-    var openingBottle: Bottle? {
-        didSet {
-            guard let openingBottle = openingBottle
-            else { return }
-
-            self.updateOpeningBottleIndexPath(forBottle: openingBottle)
-        }
-    }
-    
-    /// 현재 열고 있는 저금통의 indexPath
-    var openingBottleIndexPath: IndexPath?
-    
     
     // MARK: - init
     init() {
@@ -58,13 +44,5 @@ final class BottleListViewModel {
 //        PersistenceStore.shared.deleteAll(Bottle.self)
         
         self.bottleList = list
-    }
-    
-    /// 개봉중인 저금통의 인덱스 패스 업데이트
-    private func updateOpeningBottleIndexPath(forBottle bottle: Bottle) {
-        guard let row = self.bottleList.firstIndex(of: bottle)
-        else { return }
-        
-        self.openingBottleIndexPath = IndexPath(row: row, section: .zero)
     }
 }


### PR DESCRIPTION
## 반영내용
- 이슈 #128

<br>

### 드디어 저금통 개봉 애니메이션 찐막인것 같습니다 제발.. 
- 항상 메시지 뷰에서 탭하면 쪽지리트스가 페이드인으로 나타나도록 변경했습니다. 
- unwind segue 를 버리고 
   1. 탭바 컨트롤러의 인덱스를 저금통 리스트 탭로 이동
   2. 스토리보드 뷰컨트롤러 인스턴스화를 통해 저금통 리스트 탭의 네비게이션 뷰 체계를 [저금통 리스트, 쪽지 리스트] 로 변경
   3. 메시지 뷰 dismiss
   => 짜잔 쪽지리스트를 드리겠습니다..!

- unwind segue 를 비롯해서 기존 방식과 관련된 메서드들 다 삭제했습니다...!