### PR TITLE
[feat] 저금통 리스트 셀에 스냅샷 적용 #132

### DIFF
--- a/Happiggy-bank/Happiggy-bank/CoreData/Bottle+CoreDataClass.swift
+++ b/Happiggy-bank/Happiggy-bank/CoreData/Bottle+CoreDataClass.swift
@@ -93,7 +93,7 @@ public class Bottle: NSManagedObject {
     /// 이미지
     var image: UIImage {
         get { UIImage(data: image_ ?? Data()) ?? UIImage() }
-        set { image_ = newValue.jpegData(compressionQuality: .one) }
+        set { image_ = newValue.pngData() }
     }
     
     /// 해당 저금통에 들어있는 쪽지들의 배열

--- a/Happiggy-bank/Happiggy-bank/Extensions/UIColor+AssetColors.swift
+++ b/Happiggy-bank/Happiggy-bank/Extensions/UIColor+AssetColors.swift
@@ -44,6 +44,9 @@ extension UIColor {
     /// 탭바 구분선 색상
     static let tabBarDivider = UIColor(named: "tabBarDivider") ?? .secondaryLabel
     
+    /// 라이트모드 흰색, 다크모드 검정색
+    static let reversedLabel = UIColor(named: "tabBarBackground") ?? .customTint
+    
     
     // MARK: - Functions
     

--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="dSD-O6-Yej">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="dSD-O6-Yej">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -187,7 +187,7 @@
                             </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="4sZ-5P-EaJ"/>
-                        <color key="backgroundColor" red="0.94117647058823528" green="0.94117647058823528" blue="0.94117647058823528" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                        <color key="backgroundColor" name="homeBackground"/>
                         <constraints>
                             <constraint firstItem="iSv-QP-4wT" firstAttribute="top" secondItem="4sZ-5P-EaJ" secondAttribute="top" id="018-0K-Fk3"/>
                             <constraint firstItem="iSv-QP-4wT" firstAttribute="leading" secondItem="4sZ-5P-EaJ" secondAttribute="leading" id="38T-T7-b2w"/>

--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -761,15 +761,15 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OAt-vo-L69">
-                                <rect key="frame" x="27" y="0.0" width="360" height="769"/>
+                                <rect key="frame" x="20" y="0.0" width="374" height="769"/>
                                 <gestureRecognizers/>
                             </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Car-X3-Th6"/>
                         <gestureRecognizers/>
                         <constraints>
-                            <constraint firstAttribute="trailingMargin" secondItem="OAt-vo-L69" secondAttribute="trailing" constant="7" id="2LI-SU-Shf"/>
-                            <constraint firstItem="OAt-vo-L69" firstAttribute="leading" secondItem="jBg-oD-Piv" secondAttribute="leadingMargin" constant="7" id="KFq-lV-62y"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="OAt-vo-L69" secondAttribute="trailing" id="2LI-SU-Shf"/>
+                            <constraint firstItem="OAt-vo-L69" firstAttribute="leading" secondItem="jBg-oD-Piv" secondAttribute="leadingMargin" id="KFq-lV-62y"/>
                             <constraint firstItem="OAt-vo-L69" firstAttribute="top" secondItem="jBg-oD-Piv" secondAttribute="topMargin" id="dBa-F9-eez"/>
                             <constraint firstAttribute="bottomMargin" secondItem="OAt-vo-L69" secondAttribute="bottom" id="wb2-wb-Iwg"/>
                         </constraints>

--- a/Happiggy-bank/Happiggy-bank/Storyboard/BottleCell.xib
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/BottleCell.xib
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,8 +18,9 @@
                 <rect key="frame" x="0.0" y="0.0" width="165" height="356"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="homeBackgroundBlurredLight" translatesAutoresizingMaskIntoConstraints="NO" id="sNN-DG-3fg">
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="sNN-DG-3fg">
                         <rect key="frame" x="0.0" y="0.0" width="165" height="306"/>
+                        <color key="backgroundColor" name="homeBackground"/>
                         <constraints>
                             <constraint firstAttribute="width" secondItem="sNN-DG-3fg" secondAttribute="height" multiplier="55:102" id="MUm-Fs-ZjR"/>
                         </constraints>
@@ -55,6 +57,8 @@
         </collectionViewCell>
     </objects>
     <resources>
-        <image name="homeBackgroundBlurredLight" width="375" height="812"/>
+        <namedColor name="homeBackground">
+            <color red="0.94117647058823528" green="0.94117647058823528" blue="0.94117647058823528" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
     </resources>
 </document>

--- a/Happiggy-bank/Happiggy-bank/Storyboard/BottleCell.xib
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/BottleCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>

--- a/Happiggy-bank/Happiggy-bank/Subview/BottleCell.swift
+++ b/Happiggy-bank/Happiggy-bank/Subview/BottleCell.swift
@@ -37,6 +37,7 @@ final class BottleCell: UICollectionViewCell {
     /// 셀 이미지 설정
     private func configureImage() {
         self.bottleImage.layer.cornerRadius = Metric.cornerRadius
+        self.bottleImage.clipsToBounds = true
     }
     
     /// 셀 라벨 폰트사이즈, 색상 설정

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -97,15 +97,29 @@ extension BottleViewController {
         
         /// 현재 뷰를 기준으로 충돌 영역 설정을 위해 넣을 상하좌우 마진
         static let collisionBoundaryInsets = UIEdgeInsets(top: .zero, left: 3, bottom: 3, right: 3)
+    }
+}
+
+extension BottleViewModel {
+    /// 상수값
+    enum Metric {
         
-        /// 일주일, 한 달짜리는 영역 축소 필요
-        static let durationCap = 60
+        /// 그리드 인셋
+        static let gridEdgeInsets = UIEdgeInsets(
+            top: 30,
+            left: gridVerticalInset,
+            bottom: .zero,
+            right: gridVerticalInset
+        )
         
-        /// 일주일, 한 달인 경우 높이를 축소하기 위해 감산해줄 값
-        static let shorterMonthHeightRemovalConstant: CGFloat = 130
+        /// 1년 짜리 제외 다 영역 축소
+        static let durationCap = 300
         
-        /// 저금통 쪽지 뷰 좌우 여백: 14
-        static let bottleNoteViewDxInset: CGFloat = 14
+        /// 일주일, 한 달인 경우 높이를 축소하기 위해 감산해줄 값: 40
+        static let shorterDurationHeightRemovalConstant: CGFloat = 40
+        
+        /// 그리드 좌우 인셋: 7
+        private static let gridVerticalInset: CGFloat = 7
     }
 }
 

--- a/Happiggy-bank/Happiggy-bank/ViewController/BottleListViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/BottleListViewController.swift
@@ -153,7 +153,8 @@ extension BottleListViewController: UICollectionViewDataSource {
         cell.bottleTitleLabel.text = bottle.title
         cell.bottleDateLabel.text = bottle.dateLabel
         cell.bottleDateLabel.textColor = .customLabel
-
+        cell.bottleImage.image = bottle.image
+        
         return cell
         
     }

--- a/Happiggy-bank/Happiggy-bank/ViewController/BottleMessageViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/BottleMessageViewController.swift
@@ -101,7 +101,7 @@ final class BottleMessageViewController: UIViewController {
             delay: .zero,
             options: [.curveEaseIn, .beginFromCurrentState]
         ) {
-            self.view.backgroundColor = .white
+            self.view.backgroundColor = .reversedLabel
             self.clearContents()
         } completion: { _ in
             self.moveToNoteList()

--- a/Happiggy-bank/Happiggy-bank/ViewController/BottleViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/BottleViewController.swift
@@ -27,16 +27,12 @@ final class BottleViewController: UIViewController {
     
     /// 쪽지를 넣기 위해 bottle note view 의 영역을 나눠줄 그리드
     private lazy var grid: Grid = {
-        var bounds = self.bottleNoteView.bounds
         guard let bottle = self.viewModel.bottle
         else { return Grid(frame: .zero, cellCount: .zero) }
         
-        if bottle.duration < Metric.durationCap {
-            bounds.size.height -= Metric.shorterMonthHeightRemovalConstant
-        }
-        
+        self.bottleNoteView.frame = self.viewModel.gridFrame(forView: self.view)
         return Grid(
-            frame: bounds,
+            frame: self.bottleNoteView.bounds,
             cellCount: self.viewModel.bottle?.duration ?? .zero
         )
     }()
@@ -108,11 +104,6 @@ final class BottleViewController: UIViewController {
         guard let bottle = self.viewModel.bottle
         else { return }
         
-        /// 디바이스 크기에 따라 쪽지를 담을 영역 크기 조정
-        self.bottleNoteView.frame = self.view.bounds.insetBy(
-            dx: Metric.bottleNoteViewDxInset,
-            dy: .zero
-        )
         self.fillBottleNoteView(fromNotes: bottle.notes)
         self.addGravity()
         self.gravity?.enable()

--- a/Happiggy-bank/Happiggy-bank/ViewController/HomeViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/HomeViewController.swift
@@ -217,7 +217,7 @@ final class HomeViewController: UIViewController {
         
         if segue.identifier == SegueIdentifier.presentBottleMessageView {
             guard let bottleMessageController = segue.destination as? BottleMessageViewController,
-                  let bottle = self.viewModel.bottle
+                  let bottle = sender as? Bottle
             else { return }
             
             bottleMessageController.bottle = bottle
@@ -419,7 +419,7 @@ final class HomeViewController: UIViewController {
         self.bottleViewController.bottleDidOpen(withDuration: Duration.bottleOpeningAnimation)
         self.performSegue(
             withIdentifier: SegueIdentifier.presentBottleMessageView,
-            sender: self
+            sender: bottle
         )
     }
 }

--- a/Happiggy-bank/Happiggy-bank/ViewModel/BottleViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/BottleViewModel.swift
@@ -14,4 +14,22 @@ final class BottleViewModel {
     // MARK: - Properties
     /// 홈 뷰에서 나타낼 저금통
     var bottle: Bottle?
+    
+    
+    // MARK: - Functions
+    
+    /// 저금통 기간에 따른 그리드 프레임 리턴
+    func gridFrame(forView view: UIView) -> CGRect {
+        guard let bottle = bottle
+        else { return .zero }
+
+        var frame = view.bounds.inset(by: Metric.gridEdgeInsets)
+        
+        if bottle.duration < Metric.durationCap {
+            frame.size.height -= Metric.shorterDurationHeightRemovalConstant
+            frame.origin.y += Metric.shorterDurationHeightRemovalConstant
+        }
+        
+        return frame
+    }
 }

--- a/Happiggy-bank/Happiggy-bank/ViewModel/HomeViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/HomeViewModel.swift
@@ -71,8 +71,8 @@ final class HomeViewModel {
         let request = Bottle.fetchRequest(isOpen: false)
         var bottles = PersistenceStore.shared.fetch(request: request)
         self.bottle = bottles.first
-//        self.bottle = Bottle.foo
-//        PersistenceStore.shared.save()
+        self.bottle = Bottle.foo
+        PersistenceStore.shared.save()
     }
 
     func dDay() -> String {


### PR DESCRIPTION
## 반영내용 
- 이슈 #132 

<br>

- 저금통 리스트 셀에 스냅샷을 적용했습니다. 
  - 스냅샷 배경이 투명 그대로 유지되도록 저장시 기존 jpeg->png 로 변환했습니다. 
- 중력 작동 전 저금통 뷰에서 쪽지 최대 높이를 조정했습니다. 
- 저금통 개봉 메시지 뷰의 배경들을 다크모드도 지원하도록 변경했습니다. 
- 홈뷰에서 저금통 개봉 시 저금통을 nil 로 바꾸면서 메시지 뷰에 저금통이 전달되지 않아 sender 에 저금통을 넣어서 보내는 방식으로 변경했습니다. 
  - 그냥 저금통을 nil 로 바꾸는 순서를 맨 밑으로 내리려다가 나중에 또 헷갈릴 수 있을 것 같아 이렇게 처리했습니당 