### PR TITLE
[feat] 디테일 처리 #134 #135

### DIFF
--- a/Happiggy-bank/Happiggy-bank/CoreData/Bottle+CoreDataClass.swift
+++ b/Happiggy-bank/Happiggy-bank/CoreData/Bottle+CoreDataClass.swift
@@ -193,13 +193,13 @@ extension Bottle {
     
     /// 테스트용 목 데이터
     static let foo: Bottle = {
-        let offset = 0
+        let offset = 0 + 5
         let count = 365 - offset
         let startDate = nthDayFromToday(-count)
         let endDate = nthDayFromToday(-1 + offset)
         
         let bottle = Bottle(title: "행복냠냠이", startDate: startDate, endDate: endDate, message: "안녕")
-        for index in 0+offset..<count {
+        for index in 5+offset..<count {
             let note = Note.create(
                 date: nthDayFromToday(-index-1),
                 color: NoteColor.allCases.randomElement()!,

--- a/Happiggy-bank/Happiggy-bank/Extensions/UITextView+ParagraphStyle.swift
+++ b/Happiggy-bank/Happiggy-bank/Extensions/UITextView+ParagraphStyle.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import CoreData
 
 extension UITextView {
     
@@ -19,20 +20,16 @@ extension UITextView {
         let characterSpacing = (characterSpacing == nil) ? .zero : characterSpacing!
         let font: UIFont = (font == nil) ? (self.font ?? UIFont()) : font!
         
-        let attributedString = self.text.nsMutableAttributedStringify()
         let paragraphStyle = NSMutableParagraphStyle().then {
             $0.lineSpacing = lineSpacing
         }
         
-        attributedString.addAttributes(
-            [
-                .paragraphStyle: paragraphStyle,
-                .font: font,
-                .kern: characterSpacing
-            ],
-            range: NSRange(location: .zero, length: attributedString.length)
-        )
-
-        self.attributedText = attributedString
+        let attributes: [NSAttributedString.Key : Any] = [
+            .paragraphStyle: paragraphStyle,
+            .font: font,
+            .kern: characterSpacing
+        ]
+        
+        self.typingAttributes = attributes
     }
 }

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -811,8 +811,8 @@ extension Gravity {
     /// 상수값
     enum Metric {
         
-        /// 디바이스 모션 업데이트 주기: 0.5
-        static let deviceMotionUpdateInterval: CGFloat = 0.5
+        /// 디바이스 모션 업데이트 주기: 0.05
+        static let deviceMotionUpdateInterval: CGFloat = 1/20
     }
 }
 

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -841,20 +841,11 @@ extension NoteDetailViewController {
         /// 양 옆에 보일 아이템의 너비: 30
         static let sideItemVisibleWidth: CGFloat = 30
         
-        /// 중앙 아이템 사이즈
+        /// 중앙 아이템 사이즈(아이폰 12 기준)
         static let itemSize = CGSize(
-            width: itemWidth,
-            height: heightWidthRatio * itemWidth
+            width: 294,
+            height: 367.5
         )
-        
-        /// 아이템 좌우 패딩: 48
-        private static let itemHorizontalPadding: CGFloat = 48
-        
-        /// 아이템 너비
-        private static let itemWidth = UIScreen.main.bounds.width - 2 * itemHorizontalPadding
-        
-        /// 아이템 높이:너비 비율 : 350/280
-        private static let heightWidthRatio: CGFloat = 350/280
     }
     
     /// 애니메이션 관련 상수

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -1045,6 +1045,9 @@ extension CustomTabBar {
             bottom: -titleOffset,
             right: .zero
         )
+        
+        /// 커스텀 탭바 크기를 적용할 디바이스 최소 높이
+        static let heightCap: CGFloat = 800
     }
 }
 

--- a/Happiggy-bank/Happiggy-bank/View/CustomTabBar.swift
+++ b/Happiggy-bank/Happiggy-bank/View/CustomTabBar.swift
@@ -31,14 +31,14 @@ final class CustomTabBar: UITabBar {
         super.init(frame: frame)
         
         self.configureDivider()
-        self.configureItemPositions()
+        self.configureItemPositionsIfNeeded()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         
         self.configureDivider()
-        self.configureItemPositions()
+        self.configureItemPositionsIfNeeded()
     }
     
     
@@ -46,7 +46,10 @@ final class CustomTabBar: UITabBar {
     
     override func sizeThatFits(_ size: CGSize) -> CGSize {
         var size = super.sizeThatFits(size)
-        size.height = Metric.height
+        
+        if UIScreen.main.bounds.height >= Metric.heightCap {
+            size.height = Metric.height
+        }
 
         return size
     }
@@ -69,7 +72,10 @@ final class CustomTabBar: UITabBar {
     }
     
     /// 탭 아이템 위치 조정
-    private func configureItemPositions() {
+    private func configureItemPositionsIfNeeded() {
+        guard UIScreen.main.bounds.height >= Metric.heightCap
+        else { return }
+        
         self.items?.forEach {
             $0.imageInsets = Metric.imageInset
             $0.titlePositionAdjustment.vertical = Metric.titleOffset

--- a/Happiggy-bank/Happiggy-bank/ViewController/NewBottleMessageFieldViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NewBottleMessageFieldViewController.swift
@@ -150,31 +150,37 @@ extension NewBottleMessageFieldViewController: UITextFieldDelegate {
         shouldChangeCharactersIn range: NSRange,
         replacementString string: String
     ) -> Bool {
-        guard let text = self.textField.text,
-              let textRange = Range(range, in: text)
+        /// 텍스트가 유효한지, 편집한 범위를 찾을 수 있는 지 확인
+        guard let currentText = textField.text,
+              Range(range, in: currentText) != nil
         else { return false }
         
         let maxLength = self.textField.textInputMode?.primaryLanguage == StringLiteral.korean ?
         Metric.textFieldKoreanMaxLength :
         Metric.textFieldMaxLength
         
-        var updatedText = text.replacingCharacters(in: textRange, with: string)
+        let updatedTextLength = currentText.count - range.length + string.count
+        let trimLength = updatedTextLength - maxLength
+
+        guard updatedTextLength > maxLength,
+              string.count >= trimLength
+        else { return true }
         
-        if updatedText.count > maxLength {
-            guard let overflow = Range(
-                NSRange(
-                    location: Metric.textFieldMaxLength,
-                    length: updatedText.count - Metric.textFieldMaxLength
-                ),
-                in: updatedText
-            )
-            else { return false }
-            
-            updatedText.removeSubrange(overflow)
-            self.textField.text = updatedText
-            return false
-        }
+        /// 새로 입력된 문자열의 초과분을 삭제
+        let index = string.index(string.endIndex, offsetBy: -trimLength)
+        let trimmedReplacementText = string[..<index]
         
-        return true
+        guard let startPosition = textField.position(
+            from: textField.beginningOfDocument, offset: range.location
+        ),
+              let endPosition = textField.position(
+                from: textField.beginningOfDocument, offset: NSMaxRange(range)
+              ),
+              let textRange = textField.textRange(from: startPosition, to: endPosition)
+        else { return false }
+              
+        textField.replace(textRange, withText: String(trimmedReplacementText))
+        
+        return false
     }
 }

--- a/Happiggy-bank/Happiggy-bank/ViewController/NewBottleNameFieldViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NewBottleNameFieldViewController.swift
@@ -193,31 +193,38 @@ extension NewBottleNameFieldViewController: UITextFieldDelegate {
         shouldChangeCharactersIn range: NSRange,
         replacementString string: String
     ) -> Bool {
-        guard let text = self.textField.text,
-              let textRange = Range(range, in: text)
+        
+        /// 텍스트가 유효한지, 편집한 범위를 찾을 수 있는 지 확인
+        guard let currentText = textField.text,
+              Range(range, in: currentText) != nil
         else { return false }
         
         let maxLength = self.textField.textInputMode?.primaryLanguage == StringLiteral.korean ?
         Metric.textFieldKoreanMaxLength :
         Metric.textFieldMaxLength
         
-        var updatedText = text.replacingCharacters(in: textRange, with: string)
+        let updatedTextLength = currentText.count - range.length + string.count
+        let trimLength = updatedTextLength - maxLength
+
+        guard updatedTextLength > maxLength,
+              string.count >= trimLength
+        else { return true }
         
-        if updatedText.count > maxLength {
-            guard let overflow = Range(
-                NSRange(
-                    location: Metric.textFieldMaxLength,
-                    length: updatedText.count - Metric.textFieldMaxLength
-                ),
-                in: updatedText
-            )
-            else { return false }
-            
-            updatedText.removeSubrange(overflow)
-            self.textField.text = updatedText
-            return false
-        }
+        /// 새로 입력된 문자열의 초과분을 삭제
+        let index = string.index(string.endIndex, offsetBy: -trimLength)
+        let trimmedReplacementText = string[..<index]
         
-        return true
+        guard let startPosition = textField.position(
+            from: textField.beginningOfDocument, offset: range.location
+        ),
+              let endPosition = textField.position(
+                from: textField.beginningOfDocument, offset: NSMaxRange(range)
+              ),
+              let textRange = textField.textRange(from: startPosition, to: endPosition)
+        else { return false }
+              
+        textField.replace(textRange, withText: String(trimmedReplacementText))
+        
+        return false
     }
 }

--- a/Happiggy-bank/Happiggy-bank/ViewController/NewNoteDatePickerViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NewNoteDatePickerViewController.swift
@@ -47,6 +47,11 @@ final class NewNoteDatePickerViewController: UIViewController {
         self.scrollToInitialPosition()
         self.configureRightButton()
         self.configureSelectionIndicator()
+        self.observe(
+            selector: #selector(viewWillEnterForeground),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
     }
     
     override func viewWillLayoutSubviews() {
@@ -57,6 +62,7 @@ final class NewNoteDatePickerViewController: UIViewController {
         
         self.fadeInWarningLabel()
     }
+    
     
     // MARK: - @IBAction
     
@@ -98,8 +104,17 @@ final class NewNoteDatePickerViewController: UIViewController {
         if self.isFromNoteTextView {
             self.performSegue(
                 withIdentifier: SegueIdentifier.unwindFromNoteDatePickerToTextView,
-                sender: sender)
+                sender: sender
+            )
         }
+    }
+    
+    
+    // MARK: - @objc
+    
+    /// 다시 앱으로 돌아왔을 때 호출
+    @objc private func viewWillEnterForeground() {
+        self.restoreTintColorAndWarningLabelStatus()
     }
     
     
@@ -188,6 +203,31 @@ final class NewNoteDatePickerViewController: UIViewController {
             for: noteData,
             isSelected: true
         )
+    }
+    
+    /// 이전 상태와 같게 틴트 컬러 및 경고 라벨 상태 복구
+    private func restoreTintColorAndWarningLabelStatus() {
+        let selectedRow = self.validatedRow(self.datePickerView.selectedRow(inComponent: .zero))
+        let noteDatePickerData = self.viewModel.noteData[selectedRow]
+        
+        guard let rowView = self.datePickerView.view(
+            forRow: selectedRow,
+            forComponent: .zero
+        ) as? NewNoteDatePickerRowView
+        else { return }
+        
+        /// 선택 가능하면 틴트컬러 적용
+        rowView.dateLabel.attributedText = self.viewModel.attributedDateString(
+            for: noteDatePickerData,
+            isSelected: true
+        )
+        
+        guard noteDatePickerData.color != nil
+        else { return }
+        
+        /// 선택 불가능하면 경고 라벨
+        self.showWarningLabel = true
+        self.fadeInWarningLabel()
     }
     
     

--- a/Happiggy-bank/Happiggy-bank/ViewModel/HomeViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/HomeViewModel.swift
@@ -69,7 +69,7 @@ final class HomeViewModel {
         
         PersistenceStore.shared.deleteAll(Bottle.self)
         let request = Bottle.fetchRequest(isOpen: false)
-        var bottles = PersistenceStore.shared.fetch(request: request)
+        let bottles = PersistenceStore.shared.fetch(request: request)
         self.bottle = bottles.first
         self.bottle = Bottle.foo
         PersistenceStore.shared.save()

--- a/Happiggy-bank/Happiggy-bank/ViewModel/NewNoteDatePickerViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/NewNoteDatePickerViewModel.swift
@@ -64,10 +64,7 @@ final class NewNoteDatePickerViewModel {
         isSelected: Bool = false
     ) -> NSMutableAttributedString {
 
-        var color = UIColor.label
-        if isSelected {
-            color = (source.color == nil) ? .customTint : .customGray
-        }
+        let color = isSelected && (source.color == nil) ?  UIColor.customTint : .label
         
         return source.date
             .customFormatted(type: .spaceAndDotWithDayOfWeek)


### PR DESCRIPTION
## 반영 내용
- 이슈 #134 
- 이슈 #135 

<br>

### 텍스트뷰, 텍스트필드 글자수 제한 방식, 텍스트뷰 글자 수 초과시 삭제방식 변경
- 기존 글자 수 제한 방식 자체에 자잘하게 거슬리는 점들이 있어서 제한 방식을 변경했습니다. 
  - 100자가 초과된 상태에서 붙여넣기를 하면 그게 적용된다던가 하는... 
  - 텍스트필드도 제가 다 수정했는데(저금통 제목, 저금통 메시지, 저금통 제목 수정 3곳 맞죠...?), 혹시 제가 실수로 삭제한 파트가 있는지 확인 부탁드립니다....! 
- 텍스트뷰에서 기존에는 확인창을 누르면 deleteBackwards 메서드를 이용해서 자르고 있었는데 이게 맨 뒤가 아니라 커서의 위치 기준으로 자른다는 것을 발견했습니다. 그래서 그냥 앞에서부터 100자를 자르도록 변경했습니다. 
 - 관련해서 혹시 텍스트필드 글자 자르는 건 어디서 하고 계신가용..?

<br>

### 새로운 쪽지 텍스트뷰 백그라운드에서 되돌아올 때 뷰 설정사항 리셋 문제 해결
- 포그라운드로 돌아올때 노티를 받게 하고, 노티를 받으면 현재 선택된 행의 내용에 맞게 경고 라벨과 틴트컬러 적용 여부를 확인해서 적용하도록 변경했습니다. 


<br>

### 그 외 
- 쪽지 디테일 캐러셀의 쪽지 노트 셀 크기를 비율 -> 고정 크기로 변경했습니다. 
  - 프로맥스에서 너무 쪽지 여백이 많아져서 아이폰 12 기준으로 고정 크기를 잡아서 아예 모든 디바이스에서 고정 크기로 바꿨습니다. 
  - se~프로맥스까지 얼추 괜찮은 것 같은데 베타 돌려봐야...알겠죠...? ㅎ그흑 
- 모션 업데이트 속도를 조정했습니다. 
- 현재 탭바가 커스텀된 상태(높이, 아이템 위치)인데 se에서는 깨지는 현상이 있어 디바이스 높이가 일정 이하면 탭바 커스텀 사항이 적용되지 않도록 했습니다. 