### PR TITLE
[feat] 코어데이터 에러 알림 처리 #136

### DIFF
--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -28,6 +28,9 @@
 		A459003827E8D107003010A0 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A459003727E8D107003010A0 /* SettingsViewController.swift */; };
 		A459003A27E95D6B003010A0 /* Grid.swift in Sources */ = {isa = PBXBuildFile; fileRef = A459003927E95D6B003010A0 /* Grid.swift */; };
 		A459003C27E9C5C9003010A0 /* CGSize+Area.swift in Sources */ = {isa = PBXBuildFile; fileRef = A459003B27E9C5C9003010A0 /* CGSize+Area.swift */; };
+		A466A30C2801861100D655F4 /* ErrorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A466A30B2801861000D655F4 /* ErrorViewController.swift */; };
+		A466A30E28018BBD00D655F4 /* UIVIewController+TopMostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A466A30D28018BBD00D655F4 /* UIVIewController+TopMostViewController.swift */; };
+		A466A31028018CD800D655F4 /* UIWindowScene+TopMostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A466A30F28018CD800D655F4 /* UIWindowScene+TopMostViewController.swift */; };
 		A467B5C827DA258700AC702D /* NewNoteDatePickerRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A467B5C727DA258700AC702D /* NewNoteDatePickerRowView.swift */; };
 		A467B5CA27DA289600AC702D /* NewNoteDatePickerRowView.xib in Resources */ = {isa = PBXBuildFile; fileRef = A467B5C927DA289500AC702D /* NewNoteDatePickerRowView.xib */; };
 		A46BC1EF2800626A00C2E5B4 /* TabItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A46BC1EE2800626A00C2E5B4 /* TabItem.swift */; };
@@ -120,6 +123,9 @@
 		A459003727E8D107003010A0 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		A459003927E95D6B003010A0 /* Grid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Grid.swift; sourceTree = "<group>"; };
 		A459003B27E9C5C9003010A0 /* CGSize+Area.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGSize+Area.swift"; sourceTree = "<group>"; };
+		A466A30B2801861000D655F4 /* ErrorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorViewController.swift; sourceTree = "<group>"; };
+		A466A30D28018BBD00D655F4 /* UIVIewController+TopMostViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIVIewController+TopMostViewController.swift"; sourceTree = "<group>"; };
+		A466A30F28018CD800D655F4 /* UIWindowScene+TopMostViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIWindowScene+TopMostViewController.swift"; sourceTree = "<group>"; };
 		A467B5C727DA258700AC702D /* NewNoteDatePickerRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNoteDatePickerRowView.swift; sourceTree = "<group>"; };
 		A467B5C927DA289500AC702D /* NewNoteDatePickerRowView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NewNoteDatePickerRowView.xib; sourceTree = "<group>"; };
 		A46BC1EE2800626A00C2E5B4 /* TabItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabItem.swift; sourceTree = "<group>"; };
@@ -301,6 +307,7 @@
 				D22ADF6227F5CE8F00ECB77B /* NotificationSettingViewController.swift */,
 				D236DB8727FDD66900D7B8F0 /* NewBottleMessageFieldViewController.swift */,
 				D284A5DD27FF3EFB00D20699 /* BottleNameEditViewController.swift */,
+				A466A30B2801861000D655F4 /* ErrorViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -368,6 +375,8 @@
 				A459003B27E9C5C9003010A0 /* CGSize+Area.swift */,
 				A48E183927E71D9300B44477 /* UILabel+ParagraphStyle.swift */,
 				A41DE62D27F5F2C1002A7669 /* UIView+ZoomAnimation.swift */,
+				A466A30D28018BBD00D655F4 /* UIVIewController+TopMostViewController.swift */,
+				A466A30F28018CD800D655F4 /* UIWindowScene+TopMostViewController.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -564,6 +573,8 @@
 				A843332127DA026D00A12A54 /* NewBottleDatePickerViewController.swift in Sources */,
 				A8FC07CA27B3ECF00077A758 /* SceneDelegate.swift in Sources */,
 				A4F5715427DB8B6500E7DF9B /* NewNote.swift in Sources */,
+				A466A31028018CD800D655F4 /* UIWindowScene+TopMostViewController.swift in Sources */,
+				A466A30E28018BBD00D655F4 /* UIVIewController+TopMostViewController.swift in Sources */,
 				D2C48C0127E9DFA1006FC59E /* NoteView.swift in Sources */,
 				A456657E27CC77A9007CF70A /* Date+Formatted.swift in Sources */,
 				A81742FF27C108DC0016C921 /* HomeViewModel.swift in Sources */,
@@ -606,6 +617,7 @@
 				A4F5714727DA467900E7DF9B /* DateFormat.swift in Sources */,
 				A89CBEDD27CBDEA2005549F6 /* BottleListViewController.swift in Sources */,
 				A439F53A27EEFC28002851F4 /* SettingsViewCell.swift in Sources */,
+				A466A30C2801861100D655F4 /* ErrorViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Happiggy-bank/Happiggy-bank/Extensions/UIVIewController+TopMostViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/Extensions/UIVIewController+TopMostViewController.swift
@@ -1,0 +1,37 @@
+//
+//  UIVIewController+TopMostViewController.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/04/09.
+//
+
+import UIKit
+
+extension UIViewController {
+    
+    /// 해당 뷰 컨트롤러가 속한 뷰 체계에서 가장 상위에 있는 뷰 컨트롤러를 리턴함
+    func topMostViewController() -> UIViewController? {
+        
+        if self.presentedViewController == nil {
+            return self
+        }
+        
+        if let navigationController = self.presentedViewController as? UINavigationController {
+            let navigationTopViewController = navigationController.topViewController
+            
+            guard navigationTopViewController?.presentedViewController != nil
+            else { return navigationTopViewController }
+            
+            return navigationTopViewController?.presentedViewController?.topMostViewController()
+        }
+        
+        if let tabBarContoller = self.presentedViewController as? UITabBarController {
+            if let selectedTab = tabBarContoller.selectedViewController {
+                return selectedTab.topMostViewController()
+            }
+            return tabBarContoller.topMostViewController()
+        }
+        
+        return self.presentedViewController?.topMostViewController()
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/Extensions/UIWindowScene+TopMostViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/Extensions/UIWindowScene+TopMostViewController.swift
@@ -1,0 +1,20 @@
+//
+//  UIWindowScene+TopMostViewController.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/04/09.
+//
+
+import UIKit
+
+extension UIWindowScene {
+
+    /// 현재 윈도우의 최상단에 있는 뷰 컨트롤러 리턴
+    var topMostViewController: UIViewController? {
+        self.windows
+            .filter { $0.isKeyWindow }
+            .first?
+            .rootViewController?
+            .topMostViewController()
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/SceneDelegate.swift
+++ b/Happiggy-bank/Happiggy-bank/SceneDelegate.swift
@@ -16,7 +16,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let _ = (scene as? UIWindowScene) else { return }
+        guard let scene = (scene as? UIWindowScene)
+        else { return }
+        
+        guard PersistenceStore.fatalErrorNeeded == false
+        else {
+            scene.windows.first?.rootViewController = ErrorViewController()
+            return
+        }
+        PersistenceStore.shared.windowScene = scene
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -302,6 +302,18 @@ extension PersistenceStore {
         
         /// 공유 persistence store 의 이름 : "Happiggy-bank"
         static let sharedPersistenceStoreName = "Happiggy-bank"
+        
+        /// 저장 오류 알림 제목
+        static let saveErrorTitle = "변경사항 저장에 실패했습니다"
+        
+        /// 저장 오류 알림 내용
+        static let saveErrorMessage = """
+        디바이스의 저장 공간이 충분한지 확인해주세요.
+        같은 문제가 계속 발생하는 경우 happiggybank@gmail.com 으로 문의 부탁드립니다.
+        """
+        
+        /// 확인 버튼 제목: 확인
+        static let okButtonTitle = "확인"
     }
 }
 
@@ -1065,3 +1077,21 @@ extension HomeViewModel {
 
 /// 메인 스토리보드 이름 "main"
 let mainStoryboardName = "Main"
+
+extension ErrorViewController {
+    
+    /// 문자열
+    enum StringLiteral {
+        
+        /// 에러 내용
+        static let errorDescription = "코어데이터 오류"
+        
+        /// 에러 안내 라벨 내용
+        static let informationLabelText = """
+데이터 오류가 발생해 앱을 작동할 수 없습니다
+happiggybank@gmail.com으로 문의 부탁드립니다
+
+화면을 탭하면 앱이 종료됩니다
+"""
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/ViewController/ErrorViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/ErrorViewController.swift
@@ -1,0 +1,55 @@
+//
+//  ErrorViewController.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/04/09.
+//
+
+import UIKit
+
+/// 코어데이터 로딩 오류 발생 시 나타나는 뷰 컨트롤러
+final class ErrorViewController: UIViewController {
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.view.backgroundColor = .systemBackground
+        self.configureInformationLabel()
+    }
+    
+    
+    // MARK: - @objc
+    
+    /// 유저가 화면을 탭하면 강제 종료
+    @objc private func userDidTap(sender: UITapGestureRecognizer) {
+        fatalError(StringLiteral.errorDescription)
+    }
+    
+    
+    // MARK: - Functions
+    
+    /// 에러 안내 라벨 생성
+    private func configureInformationLabel() {
+        
+        let informationLabel = UILabel().then {
+            $0.textColor = .customWarningLabel
+            $0.numberOfLines = .zero
+            $0.textAlignment = .center
+            $0.text = StringLiteral.informationLabelText
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+
+        self.view.addSubview(informationLabel)
+        NSLayoutConstraint.activate([
+            informationLabel.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            informationLabel.centerYAnchor.constraint(equalTo: self.view.centerYAnchor)
+        ])
+        
+        self.view.addGestureRecognizer(UITapGestureRecognizer(
+            target: self,
+            action: #selector(userDidTap(sender:))
+        ))
+    }
+}


### PR DESCRIPTION
## 반영 내용
- 이슈 #136

- 앱 처음 실행 시 코어데이터 관련 중대 에러가 발생하는 경우 
  - 유저에게 에러가 발생해서 앱을 작동할 수 없고, 팀 메일로 연락달라는 라벨을 띄운 다음, 탭하면 강종되게 처리했습니다. 
  - 이를 위해 아예 해당 에러가 발생하면 루트 뷰컨을 에러 뷰컨으로 바꿔줬습니다. 
 
- 저장 실패 
  - 유저에게 변경 사항을 저장하지 못했으며, 저장공간을 확인하고 같은 문제가 반복되면 팀 메일로 연락달라는 라벨을 띄운 다음 탭하면 그냥 알림만 꺼지게 하고 강종되지는 않도록 했습니다.  