### PR TITLE
[feat] 저금통 추가 시 최종 확인 알림, 텍스트 필드 글자수 제한 초과분 삭제, 기타 버그 

### DIFF
--- a/Happiggy-bank/Happiggy-bank/Happiggy-bank.xcdatamodeld/Happigy-bank.xcdatamodel/contents
+++ b/Happiggy-bank/Happiggy-bank/Happiggy-bank.xcdatamodeld/Happigy-bank.xcdatamodel/contents
@@ -6,14 +6,14 @@
         <attribute name="id_" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="image_" optional="YES" attributeType="Binary"/>
         <attribute name="isOpen" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
-        <attribute name="message_" attributeType="String" minValueString="1" maxValueString="15"/>
+        <attribute name="message_" attributeType="String" minValueString="1"/>
         <attribute name="startDate_" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="title_" attributeType="String" minValueString="1" maxValueString="10"/>
+        <attribute name="title_" attributeType="String" minValueString="1"/>
         <relationship name="notes_" optional="YES" toMany="YES" maxCount="365" deletionRule="Cascade" destinationEntity="Note" inverseName="bottle_" inverseEntity="Note"/>
     </entity>
     <entity name="Note" representedClassName="Note" syncable="YES" codeGenerationType="category">
         <attribute name="color_" attributeType="String"/>
-        <attribute name="content_" attributeType="String" minValueString="1" maxValueString="100"/>
+        <attribute name="content_" attributeType="String" minValueString="1"/>
         <attribute name="date_" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id_" attributeType="UUID" usesScalarValueType="NO"/>
         <relationship name="bottle_" maxCount="1" deletionRule="Nullify" destinationEntity="Bottle" inverseName="notes_" inverseEntity="Bottle"/>

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -673,19 +673,19 @@ extension NewNoteTextViewController {
         static let korean = "ko-KR"
         
         /// 저장 확인 알림 제목
-        static let alertTitle = "쪽지를 저장하시겠어요?"
+        static let alertTitle = "쪽지를 추가하시겠어요?"
         
         /// 알림 내용
         static let message = """
 쪽지는 하루에 한 번 작성할 수 있고,
-저장 후에는 수정/삭제가 불가능합니다
+추가 후에는 수정/삭제가 불가능합니다
 """
         
-        /// 취소 버튼 제목
+        /// 취소 버튼 제목: "취소"
         static let cancelButtonTitle = "취소"
         
-        /// 확인 버튼 제목
-        static let confirmButtonTitle = "확인"
+        /// 확인 버튼 제목: "추가"
+        static let confirmButtonTitle = "추가"
     }
 }
 
@@ -985,6 +985,15 @@ extension NewBottleMessageFieldViewController {
         // TODO: 좋은 아이디어좀 주세요..
         /// 개봉 메시지를 적지 않았을 때 기본으로 제공되는 메시지
         static let defaultMessage = "반가워 내 행복들아!"
+        
+        /// 생성 확인 알림 제목
+        static let confirmationAlertTitle = "저금통을 추가하시겠어요?"
+        
+        /// 생성 확인 알림 내용
+        static let confirmationAlertMessage = "추가 후에는 개봉날짜 변경 및 저금통 삭제가 불가합니다."
+        
+        /// 생성 확인 알림 확인 버튼 제목: 추가
+        static let confirmationAlertConfirmButtonTitle = "추가"
     }
     
     /// NewBottleMessageFieldViewController에서 사용하는 폰트 크기

--- a/Happiggy-bank/Happiggy-bank/ViewController/BottleNameEditViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/BottleNameEditViewController.swift
@@ -225,9 +225,10 @@ extension BottleNameEditViewController: UITextFieldDelegate {
               Range(range, in: currentText) != nil
         else { return false }
         
-        let maxLength = self.textField.textInputMode?.primaryLanguage == StringLiteral.korean ?
-        Metric.textFieldKoreanMaxLength :
-        Metric.textFieldMaxLength
+//        let maxLength = self.textField.textInputMode?.primaryLanguage == StringLiteral.korean ?
+//        Metric.textFieldKoreanMaxLength :
+//        Metric.textFieldMaxLength
+        let maxLength = Metric.textFieldKoreanMaxLength
         
         let updatedTextLength = currentText.count - range.length + string.count
         let trimLength = updatedTextLength - maxLength

--- a/Happiggy-bank/Happiggy-bank/ViewController/NewBottleMessageFieldViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NewBottleMessageFieldViewController.swift
@@ -44,6 +44,8 @@ final class NewBottleMessageFieldViewController: UIViewController {
     /// 새 유리병 개봉 시점 피커 뷰 컨트롤러로 돌아가는 back button 액션
     /// 이전으로 돌아가도 현재 입력된 텍스트필드의 값이 저장되어야 하므로 델리게이트 함수 사용
     @IBAction func backButtonDidTap(_ sender: Any) {
+        
+        self.textField.endEditing(true)
         // 이전 화면으로 돌아가기
         guard let message = self.textField.text
         else { return }
@@ -57,6 +59,7 @@ final class NewBottleMessageFieldViewController: UIViewController {
     
     /// 새 유리병 데이터를 코어데이터에 저장하고 홈 뷰 컨트롤러로 되돌아가는 save button 액션
     @IBAction func saveButtonDidTap(_ sender: Any) {
+        self.textField.endEditing(true)
         self.present(self.confirmationAlert(), animated: true)
     }
     
@@ -138,7 +141,9 @@ final class NewBottleMessageFieldViewController: UIViewController {
             )
             self.fadeOut()
         }
-        let cancelAction = UIAlertAction.cancelAction()
+        let cancelAction = UIAlertAction.cancelAction { _ in
+            self.textField.becomeFirstResponder()
+        }
         
         return UIAlertController.basic(
             alertTitle: StringLiteral.confirmationAlertTitle,
@@ -150,14 +155,22 @@ final class NewBottleMessageFieldViewController: UIViewController {
 }
 
 extension NewBottleMessageFieldViewController: UITextFieldDelegate {
+
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        self.textField.resignFirstResponder()
+
+        guard let text = textField.text,
+              text.count > Metric.textFieldMaxLength
+        else { return }
+        
+        textField.text = String(text.prefix(Metric.textFieldMaxLength))
+    }
     
     /// 리턴 키를 눌렀을 때 자동으로 다음 뷰로 넘어가며, 텍스트필드의 firstResponder 해제
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        if let text = self.textField.text,
-           !text.isEmpty {
-            self.present(self.confirmationAlert(), animated: true)
-        }
-        return self.textField.resignFirstResponder()
+        textField.endEditing(true)
+        self.present(self.confirmationAlert(), animated: true)
+        return true
     }
     
     /// 최대 글자수 15자 제한

--- a/Happiggy-bank/Happiggy-bank/ViewController/NewBottleMessageFieldViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NewBottleMessageFieldViewController.swift
@@ -57,12 +57,7 @@ final class NewBottleMessageFieldViewController: UIViewController {
     
     /// 새 유리병 데이터를 코어데이터에 저장하고 홈 뷰 컨트롤러로 되돌아가는 save button 액션
     @IBAction func saveButtonDidTap(_ sender: Any) {
-        saveNewBottle()
-        self.performSegue(
-            withIdentifier: SegueIdentifier.unwindFromNewBottlePopupToHomeView,
-            sender: sender
-        )
-        self.fadeOut()
+        self.present(self.confirmationAlert(), animated: true)
     }
     
     // MARK: Functions
@@ -127,6 +122,31 @@ final class NewBottleMessageFieldViewController: UIViewController {
         self.bottomLabel.font = .systemFont(ofSize: FontSize.bottomLabelText)
         self.bottomLabel.textColor = .customTint
     }
+    
+    
+    // MARK: - Functions
+    
+    /// 생성 확인 알림을 나타냄
+    private func confirmationAlert() -> UIAlertController {
+        let confirmAction = UIAlertAction.confirmAction(
+            title: StringLiteral.confirmationAlertConfirmButtonTitle
+        ) { _ in
+            self.saveNewBottle()
+            self.performSegue(
+                withIdentifier: SegueIdentifier.unwindFromNewBottlePopupToHomeView,
+                sender: self
+            )
+            self.fadeOut()
+        }
+        let cancelAction = UIAlertAction.cancelAction()
+        
+        return UIAlertController.basic(
+            alertTitle: StringLiteral.confirmationAlertTitle,
+            alertMessage: StringLiteral.confirmationAlertMessage,
+            confirmAction: confirmAction,
+            cancelAction: cancelAction
+        )
+    }
 }
 
 extension NewBottleMessageFieldViewController: UITextFieldDelegate {
@@ -135,11 +155,7 @@ extension NewBottleMessageFieldViewController: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         if let text = self.textField.text,
            !text.isEmpty {
-            saveNewBottle()
-            self.performSegue(
-                withIdentifier: SegueIdentifier.unwindFromNewBottlePopupToHomeView,
-                sender: nil
-            )
+            self.present(self.confirmationAlert(), animated: true)
         }
         return self.textField.resignFirstResponder()
     }

--- a/Happiggy-bank/Happiggy-bank/ViewController/NewBottleMessageFieldViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NewBottleMessageFieldViewController.swift
@@ -184,9 +184,10 @@ extension NewBottleMessageFieldViewController: UITextFieldDelegate {
               Range(range, in: currentText) != nil
         else { return false }
         
-        let maxLength = self.textField.textInputMode?.primaryLanguage == StringLiteral.korean ?
-        Metric.textFieldKoreanMaxLength :
-        Metric.textFieldMaxLength
+//        let maxLength = self.textField.textInputMode?.primaryLanguage == StringLiteral.korean ?
+//        Metric.textFieldKoreanMaxLength :
+//        Metric.textFieldMaxLength
+        let maxLength = Metric.textFieldKoreanMaxLength
         
         let updatedTextLength = currentText.count - range.length + string.count
         let trimLength = updatedTextLength - maxLength

--- a/Happiggy-bank/Happiggy-bank/ViewController/NewBottleNameFieldViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NewBottleNameFieldViewController.swift
@@ -86,6 +86,7 @@ final class NewBottleNameFieldViewController: UIViewController {
             return
         }
         
+        self.textField.endEditing(true)
         self.performSegue(
             withIdentifier: SegueIdentifier.presentNewBottleDatePicker,
             sender: sender
@@ -166,25 +167,37 @@ extension NewBottleNameFieldViewController: DataProvider {
     /// 유리병 데이터에 delegate를 통해 받아온 데이터를 대입해주는 함수
     func sendNewBottleData(_ data: NewBottle) {
         self.bottleData = data
+        self.textField.becomeFirstResponder()
     }
 }
 
 extension NewBottleNameFieldViewController: UITextFieldDelegate {
     
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        guard let text = textField.text,
+              text.count > Metric.textFieldMaxLength
+        else { return }
+        
+        textField.text = String(text.prefix(Metric.textFieldMaxLength))
+        self.textField.resignFirstResponder()
+    }
+    
     /// 리턴 키를 눌렀을 때 자동으로 다음 뷰로 넘어가며, 텍스트필드의 firstResponder 해제
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         if let text = self.textField.text,
            !text.isEmpty {
+            textField.endEditing(true)
             self.performSegue(
                 withIdentifier: SegueIdentifier.presentNewBottleDatePicker,
                 sender: nil
             )
+            return true
         } else {
             HapticManager.instance.notification(type: .warning)
             self.showWarningLabel = true
             self.warningLabel.fadeIn()
         }
-        return self.textField.resignFirstResponder()
+        return false
     }
     
     /// 최대 글자수 10자 제한

--- a/Happiggy-bank/Happiggy-bank/ViewController/NewBottleNameFieldViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NewBottleNameFieldViewController.swift
@@ -212,10 +212,11 @@ extension NewBottleNameFieldViewController: UITextFieldDelegate {
               Range(range, in: currentText) != nil
         else { return false }
         
-        let maxLength = self.textField.textInputMode?.primaryLanguage == StringLiteral.korean ?
-        Metric.textFieldKoreanMaxLength :
-        Metric.textFieldMaxLength
-        
+//        let maxLength = self.textField.textInputMode?.primaryLanguage == StringLiteral.korean ?
+//        Metric.textFieldKoreanMaxLength :
+//        Metric.textFieldMaxLength
+        let maxLength = Metric.textFieldKoreanMaxLength
+
         let updatedTextLength = currentText.count - range.length + string.count
         let trimLength = updatedTextLength - maxLength
 

--- a/Happiggy-bank/Happiggy-bank/ViewController/NewNoteTextViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NewNoteTextViewController.swift
@@ -320,10 +320,11 @@ extension NewNoteTextViewController: UITextViewDelegate {
         }
 
         var overflowCap = Metric.noteTextMaxLength
-        if textView.textInputMode?.primaryLanguage == StringLiteral.korean {
-            /// 한글의 경우 초성, 중성, 종성으로 이루어져 있어서 100자를 제대로 받기 위해 제한을 1글자 키움
-            overflowCap = Metric.krOverflowCap
-        }
+//        if textView.textInputMode?.primaryLanguage == StringLiteral.korean {
+//            /// 한글의 경우 초성, 중성, 종성으로 이루어져 있어서 100자를 제대로 받기 위해 제한을 1글자 키움
+//            overflowCap = Metric.krOverflowCap
+//        }
+        overflowCap = Metric.krOverflowCap
         
         let updatedTextLength = textView.text.count - range.length + text.count
         let trimLength = updatedTextLength - overflowCap


### PR DESCRIPTION
## 반영 내용
- 이슈 #153 
- 이슈 #154 
- 이슈 #155 
- 이슈 #156 

<br>

- 저금통 추가 시 기간 변경 불가, 삭제 불가 알림을 추가했습니다. 
- 새로운 저금통 제목/메시지 작성, 기존 저금통 제목 변경 뷰에서 글자수 제한을 초과하는 경우 초과분을 삭제하도록 처리했습니다. 
- 한영 변환시 글자 수 제한이 작동하지 않는 문제를 해결했습니다. 
 - 한글과 기타 언어의 글자수 제한이 달라서 로직에 발생한 문제로 일단은 글자 수 제한을 101자로 통일했고, 추후에 더 나은 해결책을 찾아보겠습니다. 
 - 코어데이터 문자열 어트리뷰트들의 글자수 제한을 제거했습니다. 
  - 하나의 이모지가 여러 글자로 인식되어 이모지가 포함된 문자열의 경우 실제로 글자 수 제한을 초과하지 않았는데 초과했다고 저장에 실패해 제거했습니다. 
  