### PR TITLE
[feat][fix] 코어데이터 에러 디버깅 문구 추가, 100자 초과 시 빨간색으로 변경

### DIFF
--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -727,7 +727,7 @@ extension NewNoteTextViewModel {
         static let textViewNote = "textViewNote"
         
         /// 글자수 라벨 텍스트를 반환
-        static let letterCountText = " \\ \(NewNoteTextViewController.Metric.noteTextMaxLength)"
+        static let letterCountText = " / \(NewNoteTextViewController.Metric.noteTextMaxLength)"
     }
     
     /// NewNoteTextViewModel 에서 사용하는 폰트 크기

--- a/Happiggy-bank/Happiggy-bank/ViewController/BottleNameEditViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/BottleNameEditViewController.swift
@@ -84,7 +84,9 @@ final class BottleNameEditViewController: UIViewController {
             return
         }
         
-        saveBottleData(with: text)
+        guard saveBottleData(with: text) == true
+        else { return }
+        
         self.dismiss(animated: true)
     }
     
@@ -117,10 +119,22 @@ final class BottleNameEditViewController: UIViewController {
     
     // MARK: Functions
     
-    private func saveBottleData(with text: String) {
+    private func saveBottleData(with text: String) -> Bool {
         self.bottle.title = text
         self.bottle.hasFixedTitle = true
-        PersistenceStore.shared.save()
+        
+        guard let (errorTitle, errorMessage) = PersistenceStore.shared.save()
+        else { return true }
+        
+        let alert = PersistenceStore.shared.makeErrorAlert(
+            title: errorTitle,
+            message: errorMessage
+        ) { _ in
+            self.dismiss(animated: false)
+        }
+        
+        self.present(alert, animated: true)
+        return false
     }
     
     
@@ -209,7 +223,9 @@ extension BottleNameEditViewController: UITextFieldDelegate {
             return true
         }
         
-        saveBottleData(with: text)
+        guard saveBottleData(with: text) == true
+        else { return false }
+        
         self.dismiss(animated: true)
         return true
     }

--- a/Happiggy-bank/Happiggy-bank/ViewController/NewBottleMessageFieldViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NewBottleMessageFieldViewController.swift
@@ -66,10 +66,10 @@ final class NewBottleMessageFieldViewController: UIViewController {
     // MARK: Functions
     
     /// 새 저금통 저장하는 메서드
-    private func saveNewBottle() {
+    private func saveNewBottle() -> Bool {
         guard let title = self.bottleData?.name,
               let endDate = self.bottleData?.endDate
-        else { return }
+        else { return true }
         
         if let openMessage = self.bottleData.openMessage {
             _ = Bottle(
@@ -87,7 +87,22 @@ final class NewBottleMessageFieldViewController: UIViewController {
             )
         }
         
-        PersistenceStore.shared.save()
+        guard let (errorTitle, errorMessage) = PersistenceStore.shared.save()
+        else { return true }
+        
+        let alert = PersistenceStore.shared.makeErrorAlert(
+            title: errorTitle,
+            message: errorMessage
+        ) { _ in
+            self.fadeOut()
+            self.performSegue(
+                withIdentifier: SegueIdentifier.unwindFromNewBottlePopupToHomeView,
+                sender: self
+            )
+        }
+        
+        self.present(alert, animated: true)
+        return false
     }
     
     
@@ -134,7 +149,9 @@ final class NewBottleMessageFieldViewController: UIViewController {
         let confirmAction = UIAlertAction.confirmAction(
             title: StringLiteral.confirmationAlertConfirmButtonTitle
         ) { _ in
-            self.saveNewBottle()
+            guard self.saveNewBottle() == true
+            else { return }
+            
             self.performSegue(
                 withIdentifier: SegueIdentifier.unwindFromNewBottlePopupToHomeView,
                 sender: self

--- a/Happiggy-bank/Happiggy-bank/ViewController/NewNoteTextViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NewNoteTextViewController.swift
@@ -207,6 +207,9 @@ final class NewNoteTextViewController: UIViewController {
         self.yearLabel.textColor = self.viewModel.labelColor
         self.monthAndDayLabel.textColor = self.viewModel.labelColor
         self.letterCountLabel.textColor = self.viewModel.labelColor
+        self.letterCountLabel.attributedText = self.viewModel.attributedLetterCountString(
+            count: self.textView.text.count
+        )
     }
     
     /// 새로운 노트 엔티티를 생성

--- a/Happiggy-bank/Happiggy-bank/ViewModel/NewNoteTextViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/NewNoteTextViewModel.swift
@@ -59,10 +59,13 @@ final class NewNoteTextViewModel {
     
     /// 색깔 적용한 글자수 라벨 텍스트
     func attributedLetterCountString(count: Int) -> NSMutableAttributedString {
+        let color = (count > NewNoteTextViewController.Metric.noteTextMaxLength) ?
+        UIColor.customWarningLabel : .noteHighlight(for: self.newNote.color)
+        
         let countString = "\(count)"
             .nsMutableAttributedStringify()
             .bold(fontSize: Font.letterCountLabel)
-            .color(color: .noteHighlight(for: self.newNote.color))
+            .color(color: color)
         
         countString.append(StringLiteral.letterCountText.nsMutableAttributedStringify())
 


### PR DESCRIPTION
##반영내용
- 이슈 #164 
- 이슈 #163 


<br>

## 코어데이터 오류
- 일단 임시방편으로 코어데이터 에러 발생 시 알림에 문제에 관한 설명을 같이 띄워서 유저가 캡쳐해서 버그 레폿을 보냈을 때 저희가 좀 더 잘 이해할 수 있도록 했습니다...!
- 알림이 나타나자마자 사라졌던 이유는 저장 버튼을 눌렀을 때 에러가 나면 알림을 띄우고 중단되는 게 아니라 선언해뒀던 dismiss/unwind segue 가 이어서 실행되기 때문인 것 같아 에러가 발생하지 않을 때만 dismiss/unwind segue 작업을 수행하도록 분기했습니다. 

<br>

## 101자 초과 시 글자 수 라벨에서 101자 빨간색으로 변경
- 101자를 입력받는 것 자체는 100자를 온전히 입력받으려면 어쩔 수 없어서(Swift 한계...8ㅅ8) 대신에 100자를 초과하면 글자 수 라벨에서 현재 글자수 부분이 빨갛게 변하도록 했습니다. 