### PR TITLE
[feat] 홈뷰 쪽지들 상호작용 시 햅틱 반응 추가 #169 #170 #171

### DIFF
--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		A44E901727D5EB130053AC57 /* Happiggy-bank.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = A44E901527D5EB130053AC57 /* Happiggy-bank.xcdatamodeld */; };
 		A456657C27CC66FD007CF70A /* DefaultButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A817430027C112D00016C921 /* DefaultButton.swift */; };
 		A456657E27CC77A9007CF70A /* Date+Formatted.swift in Sources */ = {isa = PBXBuildFile; fileRef = A456657D27CC77A9007CF70A /* Date+Formatted.swift */; };
+		A4569CB8280FB979001E3FD6 /* Presenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4569CB7280FB979001E3FD6 /* Presenter.swift */; };
+		A4569CBA280FBA23001E3FD6 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4569CB9280FBA23001E3FD6 /* Result.swift */; };
 		A459003827E8D107003010A0 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A459003727E8D107003010A0 /* SettingsViewController.swift */; };
 		A459003A27E95D6B003010A0 /* Grid.swift in Sources */ = {isa = PBXBuildFile; fileRef = A459003927E95D6B003010A0 /* Grid.swift */; };
 		A459003C27E9C5C9003010A0 /* CGSize+Area.swift in Sources */ = {isa = PBXBuildFile; fileRef = A459003B27E9C5C9003010A0 /* CGSize+Area.swift */; };
@@ -122,6 +124,8 @@
 		A439F54327EF0698002851F4 /* SettingsLabelButtonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsLabelButtonCell.swift; sourceTree = "<group>"; };
 		A44E901627D5EB130053AC57 /* Happigy-bank.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Happigy-bank.xcdatamodel"; sourceTree = "<group>"; };
 		A456657D27CC77A9007CF70A /* Date+Formatted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Formatted.swift"; sourceTree = "<group>"; };
+		A4569CB7280FB979001E3FD6 /* Presenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presenter.swift; sourceTree = "<group>"; };
+		A4569CB9280FBA23001E3FD6 /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		A459003727E8D107003010A0 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		A459003927E95D6B003010A0 /* Grid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Grid.swift; sourceTree = "<group>"; };
 		A459003B27E9C5C9003010A0 /* CGSize+Area.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGSize+Area.swift"; sourceTree = "<group>"; };
@@ -250,6 +254,7 @@
 				A4F5714627DA467900E7DF9B /* DateFormat.swift */,
 				A4F5715727DC459B00E7DF9B /* NoteColor.swift */,
 				A46BC1EE2800626A00C2E5B4 /* TabItem.swift */,
+				A4569CB9280FBA23001E3FD6 /* Result.swift */,
 			);
 			path = Enum;
 			sourceTree = "<group>";
@@ -269,6 +274,7 @@
 			children = (
 				A843332327DA397800A12A54 /* DataProvider.swift */,
 				D2AB663D27FFFCF50003AC8C /* UpdateSender.swift */,
+				A4569CB7280FB979001E3FD6 /* Presenter.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -600,6 +606,7 @@
 				A439F54527EF0698002851F4 /* SettingsLabelButtonCell.swift in Sources */,
 				A41A506F27FF2B2E005381EF /* CustomTabBar.swift in Sources */,
 				A490AC5027DD9D2E00B04CE1 /* NoteListViewModel.swift in Sources */,
+				A4569CB8280FB979001E3FD6 /* Presenter.swift in Sources */,
 				A466A3182801E99500D655F4 /* SettingsViewModel.swift in Sources */,
 				A4F5714927DA589100E7DF9B /* NoteDatePickerData.swift in Sources */,
 				D2C48BFF27E9D60A006FC59E /* Gravity.swift in Sources */,
@@ -629,6 +636,7 @@
 				A4F5714727DA467900E7DF9B /* DateFormat.swift in Sources */,
 				A89CBEDD27CBDEA2005549F6 /* BottleListViewController.swift in Sources */,
 				A439F53A27EEFC28002851F4 /* SettingsViewCell.swift in Sources */,
+				A4569CBA280FBA23001E3FD6 /* Result.swift in Sources */,
 				A466A30C2801861100D655F4 /* ErrorViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Happiggy-bank/Happiggy-bank/Enum/Result.swift
+++ b/Happiggy-bank/Happiggy-bank/Enum/Result.swift
@@ -1,0 +1,21 @@
+//
+//  Result.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/04/20.
+//
+
+import Foundation
+
+/// 작업 결과를 나타냄
+enum Result {
+    
+    /// 성공
+    case success
+    
+    /// 실패
+    case failure
+    
+    /// 취소
+    case cancel
+}

--- a/Happiggy-bank/Happiggy-bank/Protocol/Presenter.swift
+++ b/Happiggy-bank/Happiggy-bank/Protocol/Presenter.swift
@@ -1,0 +1,15 @@
+//
+//  Presenter.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/04/20.
+//
+
+import Foundation
+
+/// 자식 뷰컨트롤러를 종료할 때 부모 뷰컨트롤러에게 알리기 위한 프로토콜
+protocol Presenter: AnyObject {
+    
+    /// 자식 뷰 컨트롤러가 종료되었음을 알리는 메서드
+    func presentedViewControllerDidDismiss(withResult: Result)
+}

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -97,6 +97,9 @@ extension BottleViewController {
         
         /// 현재 뷰를 기준으로 충돌 영역 설정을 위해 넣을 상하좌우 마진
         static let collisionBoundaryInsets = UIEdgeInsets(top: .zero, left: 3, bottom: 3, right: 3)
+        
+        /// 쪽지들이 바운더리와 부딪칠 때 햅틱 반응의 강도: 0.4
+        static let impactHapticIntensity: CGFloat = 0.4
     }
 }
 

--- a/Happiggy-bank/Happiggy-bank/Utils/HapticManager.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/HapticManager.swift
@@ -26,4 +26,11 @@ final class HapticManager {
         generator.prepare()
         generator.selectionChanged()
     }
+    
+    /// 유저의 경험을 풍부하게 하기 위한 햅틱 반응
+    func impact(style: UIImpactFeedbackGenerator.FeedbackStyle, intensity: CGFloat = 1) {
+        let generator = UIImpactFeedbackGenerator(style: style)
+        generator.prepare()
+        generator.impactOccurred(intensity: intensity)
+    }
 }

--- a/Happiggy-bank/Happiggy-bank/ViewController/HomeViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/HomeViewController.swift
@@ -164,7 +164,9 @@ final class HomeViewController: UIViewController {
         ) as! BottleNameEditViewController
         
         bottleNameEditViewController.bottle = self.viewModel.bottle
+        bottleNameEditViewController.delegate = self
         self.present(bottleNameEditViewController, animated: true)
+        self.bottleViewController.alertOrModalDidAppear()
     }
     // swiftlint:enable force_cast
     
@@ -366,5 +368,14 @@ final class HomeViewController: UIViewController {
             alertMessage: StringLiteral.noEmptyDateAlertMessage,
             confirmAction: UIAlertAction.confirmAction()
         )
+    }
+}
+
+
+// MARK: - Presenter
+extension HomeViewController: Presenter {
+    
+    func presentedViewControllerDidDismiss(withResult: Result) {
+        self.bottleViewController.restoreStateBeforeAlertOrModalDidAppear()
     }
 }


### PR DESCRIPTION
## 반영 내용
- 이슈 #169 
- 이슈 #170 

<br>

### 홈뷰 쪽지들 상호작용 시 햅틱 반응 추가
- 쪽지들끼리 부딪힐 때 햅틱을 추가하면 정말 진동이 드드드드드드드드득거려서 쪽지가 바운더리와 충돌할 때만 햅틱을 추가했습니다. 
- 저금통 이름 변경 뷰컨트롤러를 띄울 때 중력을 중단했습니다.
  - 다른 모달의 경우 다 중력을 아예 중단하거나, 방향을 아래로 고정시키는 등의 작업을 했었는데 저금통 이름 변경 컨트롤러만 호출 방식이 달라서 귀찮아서...그냥 냅뒀었는데요...
  - 햅틱을 더 추가하니까 이름 바꾸는 데 계속 진동이 와서 중력을 중단시켰고, 은빈님의 data provider 처럼 프로토콜+델리게이트로 결합도를 낮췄습니다...!