### PR TITLE
[feat] 환경설정 탭의 고객지원뷰, 라이선스뷰 구현 #144 #173

### DIFF
--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -26,6 +26,15 @@
 		A456657E27CC77A9007CF70A /* Date+Formatted.swift in Sources */ = {isa = PBXBuildFile; fileRef = A456657D27CC77A9007CF70A /* Date+Formatted.swift */; };
 		A4569CB8280FB979001E3FD6 /* Presenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4569CB7280FB979001E3FD6 /* Presenter.swift */; };
 		A4569CBA280FBA23001E3FD6 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4569CB9280FBA23001E3FD6 /* Result.swift */; };
+		A4569CBC2810455B001E3FD6 /* CustomerServiceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4569CBB2810455B001E3FD6 /* CustomerServiceViewController.swift */; };
+		A4569CBE28105052001E3FD6 /* CustomerServiceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4569CBD28105051001E3FD6 /* CustomerServiceViewModel.swift */; };
+		A4569CC0281118DE001E3FD6 /* InformationTextViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4569CBF281118DE001E3FD6 /* InformationTextViewController.swift */; };
+		A4569CC428111E1D001E3FD6 /* LicenseViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4569CC328111E1D001E3FD6 /* LicenseViewModel.swift */; };
+		A4569CC628111EFA001E3FD6 /* InformationTextViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4569CC528111EFA001E3FD6 /* InformationTextViewDataSource.swift */; };
+		A4569CC828112657001E3FD6 /* LicenseText.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4569CC728112657001E3FD6 /* LicenseText.swift */; };
+		A4569CCA28113F0F001E3FD6 /* NSMutableAttributedString+Hyperlink.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4569CC928113F0F001E3FD6 /* NSMutableAttributedString+Hyperlink.swift */; };
+		A4569CCF28128B4B001E3FD6 /* SettingsNonIconButtonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4569CCD28128B4B001E3FD6 /* SettingsNonIconButtonCell.swift */; };
+		A4569CD028128B4B001E3FD6 /* SettingsNonIconButtonCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = A4569CCE28128B4B001E3FD6 /* SettingsNonIconButtonCell.xib */; };
 		A459003827E8D107003010A0 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A459003727E8D107003010A0 /* SettingsViewController.swift */; };
 		A459003A27E95D6B003010A0 /* Grid.swift in Sources */ = {isa = PBXBuildFile; fileRef = A459003927E95D6B003010A0 /* Grid.swift */; };
 		A459003C27E9C5C9003010A0 /* CGSize+Area.swift in Sources */ = {isa = PBXBuildFile; fileRef = A459003B27E9C5C9003010A0 /* CGSize+Area.swift */; };
@@ -126,6 +135,15 @@
 		A456657D27CC77A9007CF70A /* Date+Formatted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Formatted.swift"; sourceTree = "<group>"; };
 		A4569CB7280FB979001E3FD6 /* Presenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presenter.swift; sourceTree = "<group>"; };
 		A4569CB9280FBA23001E3FD6 /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
+		A4569CBB2810455B001E3FD6 /* CustomerServiceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerServiceViewController.swift; sourceTree = "<group>"; };
+		A4569CBD28105051001E3FD6 /* CustomerServiceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerServiceViewModel.swift; sourceTree = "<group>"; };
+		A4569CBF281118DE001E3FD6 /* InformationTextViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationTextViewController.swift; sourceTree = "<group>"; };
+		A4569CC328111E1D001E3FD6 /* LicenseViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicenseViewModel.swift; sourceTree = "<group>"; };
+		A4569CC528111EFA001E3FD6 /* InformationTextViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationTextViewDataSource.swift; sourceTree = "<group>"; };
+		A4569CC728112657001E3FD6 /* LicenseText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicenseText.swift; sourceTree = "<group>"; };
+		A4569CC928113F0F001E3FD6 /* NSMutableAttributedString+Hyperlink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+Hyperlink.swift"; sourceTree = "<group>"; };
+		A4569CCD28128B4B001E3FD6 /* SettingsNonIconButtonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNonIconButtonCell.swift; sourceTree = "<group>"; };
+		A4569CCE28128B4B001E3FD6 /* SettingsNonIconButtonCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingsNonIconButtonCell.xib; sourceTree = "<group>"; };
 		A459003727E8D107003010A0 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		A459003927E95D6B003010A0 /* Grid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Grid.swift; sourceTree = "<group>"; };
 		A459003B27E9C5C9003010A0 /* CGSize+Area.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGSize+Area.swift"; sourceTree = "<group>"; };
@@ -244,6 +262,7 @@
 				D22ADF7E27F72F7300ECB77B /* NotificationSettingViewModel.swift */,
 				D236DB8527FDC43200D7B8F0 /* NewBottleDatePickerViewModel.swift */,
 				A466A3172801E99500D655F4 /* SettingsViewModel.swift */,
+				A4569CBD28105051001E3FD6 /* CustomerServiceViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -288,6 +307,7 @@
 				A439F53927EEFC27002851F4 /* SettingsViewCell.swift */,
 				A439F53B27EEFCF6002851F4 /* SettingsToggleButtonCell.swift */,
 				A439F54327EF0698002851F4 /* SettingsLabelButtonCell.swift */,
+				A4569CCD28128B4B001E3FD6 /* SettingsNonIconButtonCell.swift */,
 				A41DE62927F36E95002A7669 /* NoteCell.swift */,
 			);
 			path = Subview;
@@ -321,6 +341,7 @@
 				D236DB8727FDD66900D7B8F0 /* NewBottleMessageFieldViewController.swift */,
 				D284A5DD27FF3EFB00D20699 /* BottleNameEditViewController.swift */,
 				A466A30B2801861000D655F4 /* ErrorViewController.swift */,
+				A4569CBB2810455B001E3FD6 /* CustomerServiceViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -350,6 +371,7 @@
 				A48E183D27E737B600B44477 /* CapsuleButton.xib */,
 				A439F53C27EEFCF6002851F4 /* SettingsToggleButtonCell.xib */,
 				A466A3152801DF1400D655F4 /* SettingsLabelButtonCell.xib */,
+				A4569CCE28128B4B001E3FD6 /* SettingsNonIconButtonCell.xib */,
 			);
 			path = Storyboard;
 			sourceTree = "<group>";
@@ -518,6 +540,7 @@
 				A48E183E27E737B600B44477 /* CapsuleButton.xib in Resources */,
 				A439F53E27EEFCF6002851F4 /* SettingsToggleButtonCell.xib in Resources */,
 				A466A3162801DF1400D655F4 /* SettingsLabelButtonCell.xib in Resources */,
+				A4569CD028128B4B001E3FD6 /* SettingsNonIconButtonCell.xib in Resources */,
 				A41DE62C27F36E95002A7669 /* NoteCell.xib in Resources */,
 				A8FC07D127B3ECF30077A758 /* Assets.xcassets in Resources */,
 				A8FC07CF27B3ECF00077A758 /* Main.storyboard in Resources */,
@@ -558,11 +581,13 @@
 				A41DE62B27F36E95002A7669 /* NoteCell.swift in Sources */,
 				A4C1AFD227E5C60E0096CD3E /* NewNoteTextViewModel.swift in Sources */,
 				A819CFA127DE034F00DE8E72 /* NewBottle.swift in Sources */,
+				A4569CBC2810455B001E3FD6 /* CustomerServiceViewController.swift in Sources */,
 				A456657C27CC66FD007CF70A /* DefaultButton.swift in Sources */,
 				D236DB8627FDC43200D7B8F0 /* NewBottleDatePickerViewModel.swift in Sources */,
 				A499318327BF5158009FF5A8 /* BottleNoteView.swift in Sources */,
 				A4CF2C8E27CBA49D001B01B1 /* UIViewController+NotificationCenter.swift in Sources */,
 				A46BC1EF2800626A00C2E5B4 /* TabItem.swift in Sources */,
+				A4569CBE28105052001E3FD6 /* CustomerServiceViewModel.swift in Sources */,
 				D284A5DE27FF3EFB00D20699 /* BottleNameEditViewController.swift in Sources */,
 				A466A31C28029D7400D655F4 /* UIAlertController+BasicFormat.swift in Sources */,
 				A8BD834D27BE39D600E0DE41 /* NoteProgressLabel.swift in Sources */,
@@ -579,6 +604,7 @@
 				A4CF2C8027C733FE001B01B1 /* ColorButton.swift in Sources */,
 				A4CF2C8227C73B42001B01B1 /* UIColor+AssetColors.swift in Sources */,
 				A819CF9F27DDD97C00DE8E72 /* HapticManager.swift in Sources */,
+				A4569CCF28128B4B001E3FD6 /* SettingsNonIconButtonCell.swift in Sources */,
 				A8ECD4A727E33BFA00886BC0 /* BottleListViewModel.swift in Sources */,
 				A843332427DA397800A12A54 /* DataProvider.swift in Sources */,
 				A48E183A27E71D9300B44477 /* UILabel+ParagraphStyle.swift in Sources */,

--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -418,6 +418,7 @@
 				A466A30F28018CD800D655F4 /* UIWindowScene+TopMostViewController.swift */,
 				A466A3192802987700D655F4 /* UIAlertAction+ConfirmAndCancel.swift */,
 				A466A31B28029D7400D655F4 /* UIAlertController+BasicFormat.swift */,
+				A4569CC928113F0F001E3FD6 /* NSMutableAttributedString+Hyperlink.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -598,6 +599,7 @@
 				A8BD834D27BE39D600E0DE41 /* NoteProgressLabel.swift in Sources */,
 				A8509E6E27C89A1200855153 /* UIColor+Extension.swift in Sources */,
 				D236DB8827FDD66900D7B8F0 /* NewBottleMessageFieldViewController.swift in Sources */,
+				A4569CCA28113F0F001E3FD6 /* NSMutableAttributedString+Hyperlink.swift in Sources */,
 				A490AC4E27DD945E00B04CE1 /* NoteListViewController.swift in Sources */,
 				A8BD834727BE337900E0DE41 /* HomeView.swift in Sources */,
 				A4CF2C7C27C71FF5001B01B1 /* CATransition+PopupAnimation.swift in Sources */,

--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -263,6 +263,7 @@
 				D236DB8527FDC43200D7B8F0 /* NewBottleDatePickerViewModel.swift */,
 				A466A3172801E99500D655F4 /* SettingsViewModel.swift */,
 				A4569CBD28105051001E3FD6 /* CustomerServiceViewModel.swift */,
+				A4569CC328111E1D001E3FD6 /* LicenseViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -294,6 +295,7 @@
 				A843332327DA397800A12A54 /* DataProvider.swift */,
 				D2AB663D27FFFCF50003AC8C /* UpdateSender.swift */,
 				A4569CB7280FB979001E3FD6 /* Presenter.swift */,
+				A4569CC528111EFA001E3FD6 /* InformationTextViewDataSource.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -342,6 +344,7 @@
 				D284A5DD27FF3EFB00D20699 /* BottleNameEditViewController.swift */,
 				A466A30B2801861000D655F4 /* ErrorViewController.swift */,
 				A4569CBB2810455B001E3FD6 /* CustomerServiceViewController.swift */,
+				A4569CBF281118DE001E3FD6 /* InformationTextViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -355,6 +358,7 @@
 				A459003927E95D6B003010A0 /* Grid.swift */,
 				A425F8B527EDF4FB00A005AB /* TagViewFlowLayout.swift */,
 				A41DE62327F34ABB002A7669 /* UPCarouselFlowLayout.swift */,
+				A4569CC728112657001E3FD6 /* LicenseText.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -582,6 +586,7 @@
 				A4C1AFD227E5C60E0096CD3E /* NewNoteTextViewModel.swift in Sources */,
 				A819CFA127DE034F00DE8E72 /* NewBottle.swift in Sources */,
 				A4569CBC2810455B001E3FD6 /* CustomerServiceViewController.swift in Sources */,
+				A4569CC628111EFA001E3FD6 /* InformationTextViewDataSource.swift in Sources */,
 				A456657C27CC66FD007CF70A /* DefaultButton.swift in Sources */,
 				D236DB8627FDC43200D7B8F0 /* NewBottleDatePickerViewModel.swift in Sources */,
 				A499318327BF5158009FF5A8 /* BottleNoteView.swift in Sources */,
@@ -616,6 +621,7 @@
 				A8FC07CA27B3ECF00077A758 /* SceneDelegate.swift in Sources */,
 				A4F5715427DB8B6500E7DF9B /* NewNote.swift in Sources */,
 				A466A31028018CD800D655F4 /* UIWindowScene+TopMostViewController.swift in Sources */,
+				A4569CC428111E1D001E3FD6 /* LicenseViewModel.swift in Sources */,
 				A466A30E28018BBD00D655F4 /* UIVIewController+TopMostViewController.swift in Sources */,
 				D2C48C0127E9DFA1006FC59E /* NoteView.swift in Sources */,
 				A456657E27CC77A9007CF70A /* Date+Formatted.swift in Sources */,
@@ -651,12 +657,14 @@
 				A44E901727D5EB130053AC57 /* Happiggy-bank.xcdatamodeld in Sources */,
 				A4C1AFD427E5E6120096CD3E /* UITextView+ParagraphStyle.swift in Sources */,
 				A466A31A2802987700D655F4 /* UIAlertAction+ConfirmAndCancel.swift in Sources */,
+				A4569CC828112657001E3FD6 /* LicenseText.swift in Sources */,
 				A49931A527BFD20E009FF5A8 /* UIImage+AssetImages.swift in Sources */,
 				A459003A27E95D6B003010A0 /* Grid.swift in Sources */,
 				A4C1AFC227E47AD80096CD3E /* String+EmptyString.swift in Sources */,
 				A4C1AFC627E482E10096CD3E /* CGFloat+Values.swift in Sources */,
 				A8BD833F27BE30B400E0DE41 /* Constants.swift in Sources */,
 				A41DE62827F368BF002A7669 /* NoteDetailViewModel.swift in Sources */,
+				A4569CC0281118DE001E3FD6 /* InformationTextViewController.swift in Sources */,
 				A41DE62627F36595002A7669 /* NoteDetailViewController.swift in Sources */,
 				A41DE62427F34ABB002A7669 /* UPCarouselFlowLayout.swift in Sources */,
 				A4F5714727DA467900E7DF9B /* DateFormat.swift in Sources */,

--- a/Happiggy-bank/Happiggy-bank/Extensions/NSMutableAttributedString+ColorBold.swift
+++ b/Happiggy-bank/Happiggy-bank/Extensions/NSMutableAttributedString+ColorBold.swift
@@ -16,6 +16,7 @@ extension NSMutableAttributedString {
     
     /// 문자열에서 targetString 부분만  fontSize 크기로 볼드 처리해서 NSMutableAttributedString 의 형태로 리턴
     /// targetString 을 빈 문자열로 설정하면 전체를 변경
+    @discardableResult
     func bold(targetString: String = .empty, fontSize: CGFloat) -> NSMutableAttributedString {
         let targetString = returnSelfIfTargetIsEmpty(targetString: targetString)
         let boldFont = UIFont.boldSystemFont(ofSize: fontSize)
@@ -27,6 +28,7 @@ extension NSMutableAttributedString {
     
     /// 문자열에서 targetString 부분만 색깔을 변경해서 NSMutableAttributedString 의 형태로 리턴
     /// targetString 을 빈 문자열로 설정하면 전체를 변경
+    @discardableResult
     func color(targetString: String = .empty, color: UIColor) -> NSMutableAttributedString {
         let targetString = returnSelfIfTargetIsEmpty(targetString: targetString)
         let range = self.mutableString.range(of: targetString)

--- a/Happiggy-bank/Happiggy-bank/Extensions/NSMutableAttributedString+Hyperlink.swift
+++ b/Happiggy-bank/Happiggy-bank/Extensions/NSMutableAttributedString+Hyperlink.swift
@@ -1,0 +1,22 @@
+//
+//  NSMutableAttributedString+Hyperlink.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/04/21.
+//
+
+import Foundation
+
+extension NSMutableAttributedString {
+    
+    /// 지정한 문자열에 하이퍼링크 추가
+    @discardableResult
+    func addHyperLinks(hyperlinks: [String: String]) -> NSMutableAttributedString {
+        for (hyperlink, urlString) in hyperlinks {
+            let linkRange = self.mutableString.range(of: hyperlink)
+            self.addAttribute(NSAttributedString.Key.link, value: urlString, range: linkRange)
+        }
+        
+        return self
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/Protocol/InformationTextViewDataSource.swift
+++ b/Happiggy-bank/Happiggy-bank/Protocol/InformationTextViewDataSource.swift
@@ -1,0 +1,18 @@
+//
+//  InformationTextViewDataSource.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/04/21.
+//
+
+import Foundation
+
+/// 정보 텍스트 뷰 데이터 소스
+protocol InformationTextViewDataSource: AnyObject {
+    
+    /// 내비게이션 바 제목
+    var navigationTitle: String? { get }
+    
+    /// 정보 텍스트
+    var attributedInformationString: NSAttributedString? { get }
+}

--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -556,6 +556,7 @@
                     <connections>
                         <outlet property="tableView" destination="uQp-S9-PAW" id="wxA-zr-YMs"/>
                         <outlet property="teamLabel" destination="xZO-XM-fFz" id="OWN-SM-M6q"/>
+                        <segue destination="nkh-H8-Hta" kind="show" identifier="showLicenseView" id="53q-OE-6qo"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="rhR-vq-qOh" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -565,7 +566,41 @@
                     </connections>
                 </tapGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="4110" y="2446"/>
+            <point key="canvasLocation" x="4316" y="2462"/>
+        </scene>
+        <!--Information Text View Controller-->
+        <scene sceneID="av6-PB-qbi">
+            <objects>
+                <viewController storyboardIdentifier="InformationTextViewController" id="nkh-H8-Hta" customClass="InformationTextViewController" customModule="Happiggy_bank" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Rgl-PJ-7HD">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="813"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsVerticalScrollIndicator="NO" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="tZn-mi-dNg">
+                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="textColor" systemColor="labelColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="9fX-sQ-sEU"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="tZn-mi-dNg" firstAttribute="leading" secondItem="9fX-sQ-sEU" secondAttribute="leading" id="DL2-nt-Vwx"/>
+                            <constraint firstItem="9fX-sQ-sEU" firstAttribute="trailing" secondItem="tZn-mi-dNg" secondAttribute="trailing" id="UjB-vm-cWZ"/>
+                            <constraint firstItem="tZn-mi-dNg" firstAttribute="top" secondItem="9fX-sQ-sEU" secondAttribute="top" id="idE-qx-uMQ"/>
+                            <constraint firstItem="9fX-sQ-sEU" firstAttribute="bottom" secondItem="tZn-mi-dNg" secondAttribute="bottom" id="pnA-bI-ptG"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="E0r-r8-K2q"/>
+                    <connections>
+                        <outlet property="textView" destination="tZn-mi-dNg" id="8ea-E1-nPB"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="CGH-cf-NE3" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4316" y="3183"/>
         </scene>
         <!--환경설정-->
         <scene sceneID="vw8-MY-aV0">

--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -479,6 +479,7 @@
                     <connections>
                         <outlet property="tableView" destination="XH5-F4-UT7" id="Su4-TC-HON"/>
                         <outlet property="teamLabel" destination="b4d-oF-HEA" id="NyI-hP-fmw"/>
+                        <segue destination="Tl4-Fc-9VF" kind="show" identifier="showCustomerServiceView" id="qcB-dq-xct"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="aNi-4h-ywR" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -489,6 +490,82 @@
                 </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="2965.5999999999999" y="1642.6108374384237"/>
+        </scene>
+        <!--고객 지원-->
+        <scene sceneID="5tL-nS-PV6">
+            <objects>
+                <viewController id="Tl4-Fc-9VF" customClass="CustomerServiceViewController" customModule="Happiggy_bank" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="y8a-by-6kU">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="813"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="79" estimatedRowHeight="79" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="uQp-S9-PAW">
+                                <rect key="frame" x="0.0" y="88" width="414" height="628"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <connections>
+                                    <outlet property="dataSource" destination="Tl4-Fc-9VF" id="c5C-I0-D53"/>
+                                    <outlet property="delegate" destination="Tl4-Fc-9VF" id="E3V-Gc-lfh"/>
+                                </connections>
+                            </tableView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="zPR-tj-0Fk">
+                                <rect key="frame" x="127" y="732" width="160" height="57"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Happiggy" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xVA-yW-8B5">
+                                        <rect key="frame" x="0.0" y="0.0" width="160" height="17"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <color key="textColor" name="customGray"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="xZO-XM-fFz">
+                                        <rect key="frame" x="0.0" y="24" width="160" height="33"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2unbini mseo sun h1" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J3d-Ov-mmP">
+                                                <rect key="frame" x="0.0" y="0.0" width="160" height="17"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <color key="textColor" name="customGray"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="happiggybank@gmail.com" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NZA-in-aRZ">
+                                                <rect key="frame" x="0.0" y="17" width="160" height="16"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                <color key="textColor" name="customGray"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <gestureRecognizers/>
+                                        <connections>
+                                            <outletCollection property="gestureRecognizers" destination="bk9-d1-qQ2" appends="YES" id="CMV-YJ-mKO"/>
+                                        </connections>
+                                    </stackView>
+                                </subviews>
+                                <gestureRecognizers/>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="Mqq-87-g65"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="zPR-tj-0Fk" firstAttribute="centerX" secondItem="y8a-by-6kU" secondAttribute="centerX" id="2bd-n4-rI8"/>
+                            <constraint firstItem="uQp-S9-PAW" firstAttribute="top" secondItem="Mqq-87-g65" secondAttribute="top" id="77z-3S-GX4"/>
+                            <constraint firstItem="Mqq-87-g65" firstAttribute="bottom" secondItem="zPR-tj-0Fk" secondAttribute="bottom" constant="24" id="V4f-Ta-9Ye"/>
+                            <constraint firstItem="Mqq-87-g65" firstAttribute="trailing" secondItem="uQp-S9-PAW" secondAttribute="trailing" id="YP0-iC-Wm6"/>
+                            <constraint firstItem="zPR-tj-0Fk" firstAttribute="top" secondItem="uQp-S9-PAW" secondAttribute="bottom" constant="16" id="k0b-eI-8tA"/>
+                            <constraint firstItem="uQp-S9-PAW" firstAttribute="leading" secondItem="Mqq-87-g65" secondAttribute="leading" id="m2K-YV-2Si"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" title="고객 지원" id="Pv5-p6-rLV"/>
+                    <connections>
+                        <outlet property="tableView" destination="uQp-S9-PAW" id="wxA-zr-YMs"/>
+                        <outlet property="teamLabel" destination="xZO-XM-fFz" id="OWN-SM-M6q"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="rhR-vq-qOh" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <tapGestureRecognizer id="bk9-d1-qQ2">
+                    <connections>
+                        <action selector="teamLabelDidTap:" destination="Tl4-Fc-9VF" id="Ptm-Kx-BiZ"/>
+                    </connections>
+                </tapGestureRecognizer>
+            </objects>
+            <point key="canvasLocation" x="4110" y="2446"/>
         </scene>
         <!--환경설정-->
         <scene sceneID="vw8-MY-aV0">

--- a/Happiggy-bank/Happiggy-bank/Storyboard/SettingsNonIconButtonCell.xib
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/SettingsNonIconButtonCell.xib
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="default" indentationWidth="10" reuseIdentifier="SettingsNonIconButtonCell" rowHeight="34" id="KGk-i7-Jjw" customClass="SettingsNonIconButtonCell" customModule="Happiggy_bank" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="164" height="33"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="164" height="33"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TwN-DQ-3KX">
+                        <rect key="frame" x="0.0" y="6.5" width="39.5" height="20"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="next" translatesAutoresizingMaskIntoConstraints="NO" id="kV0-cX-Q2R">
+                        <rect key="frame" x="151" y="10" width="13" height="13"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="13" id="NAa-u4-Chx"/>
+                            <constraint firstAttribute="width" secondItem="kV0-cX-Q2R" secondAttribute="height" multiplier="1:1" id="UNr-Bq-P8l"/>
+                        </constraints>
+                    </imageView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="kV0-cX-Q2R" firstAttribute="centerY" secondItem="TwN-DQ-3KX" secondAttribute="centerY" id="7aR-xU-9eB"/>
+                    <constraint firstAttribute="trailing" secondItem="kV0-cX-Q2R" secondAttribute="trailing" id="Vzl-5x-Q29"/>
+                    <constraint firstItem="TwN-DQ-3KX" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="rTE-tv-HQt"/>
+                    <constraint firstItem="TwN-DQ-3KX" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="tjU-BF-iUz"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="buttonImage" destination="kV0-cX-Q2R" id="QlX-e7-25n"/>
+                <outlet property="titleLabel" destination="TwN-DQ-3KX" id="nbN-uU-acC"/>
+            </connections>
+            <point key="canvasLocation" x="-36.231884057971016" y="59.263392857142854"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <image name="next" width="10" height="18"/>
+    </resources>
+</document>

--- a/Happiggy-bank/Happiggy-bank/Subview/SettingsNonIconButtonCell.swift
+++ b/Happiggy-bank/Happiggy-bank/Subview/SettingsNonIconButtonCell.swift
@@ -1,0 +1,34 @@
+//
+//  SettingsNonIconButtonCell.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/04/22.
+//
+
+import UIKit
+
+/// 환경설정 하위 항목들에서 사용하는 아이콘이 없는 셀
+final class SettingsNonIconButtonCell: SettingsViewCell {
+    
+    // MARK: - @IBOutlets
+    
+    /// 제목 라벨
+    @IBOutlet weak var titleLabel: UILabel!
+    
+    /// 버튼 이미지 뷰
+    @IBOutlet weak var buttonImage: UIImageView!
+    
+
+    // MARK: - Override functions
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        self.titleLabel.attributedText = nil
+        self.titleLabel.text = nil
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -1190,3 +1190,13 @@ extension CustomerServiceViewModel {
         static let license = "라이선스"
     }
 }
+
+extension LicenseViewModel {
+    
+    /// 폰트 관련 상수
+    enum Font {
+        
+        /// 볼드체 사이즈: 14
+        static let boldFontSize: CGFloat = 14
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -768,22 +768,22 @@ extension SettingsViewController {
         /// 앱 버전 정보
         case appVersion
         
-        /// 라이선스
-//        case license
+        /// 고객 지원
+        case customerService
         
         
         // MARK: - Properties
         
         /// 아이콘 딕셔너리
         static let icon: [Int: UIImage?] = [
-            appVersion.rawValue: UIImage(named: imageName(for: .appVersion))
-//            appVersion.rawValue: UIImage(named: imageName(for: .license))
+            appVersion.rawValue: UIImage(named: imageName(for: .appVersion)),
+            customerService.rawValue: UIImage(named: imageName(for: .customerService))
         ]
         
         /// 제목 딕셔너리
         static let title: [Int: String] = [
-            appVersion.rawValue: "버전 정보"
-//            license.rawValue: "라이선스"
+            appVersion.rawValue: "버전 정보",
+            customerService.rawValue: "고객 지원"
         ]
         
         /// 추가 정보 딕셔너리
@@ -791,12 +791,30 @@ extension SettingsViewController {
             appVersion.rawValue: "최신 버전을 사용 중 입니다"
         ]
         
-        private static func imageName(for contentCase: Content) -> String {
+        /// 세그웨이 아이디 딕셔너리
+        static let segueIdentifier: [Int: String] = [
+            customerService.rawValue: segueIdentifier(for: customerService)
+        ]
+        
+        
+        // MARK: - Functions
+        
+        /// 케이스 이름을 카멜케이스로 변환
+        private static func nameInCamelCase(_ contentCase: Content) -> String {
             var contentCase = "\(contentCase.self)"
             let firstLetter = contentCase.removeFirst().uppercased()
-            contentCase = firstLetter.appending(contentCase)
             
-            return "\(Asset.settings.rawValue)\(contentCase)"
+            return firstLetter.appending(contentCase)
+        }
+        
+        /// 세그웨이 아이디 리턴
+        private static func segueIdentifier(for contentCase: Content) -> String {
+            "show\(nameInCamelCase(contentCase))View"
+        }
+        
+        /// 이미지 이름 리턴
+        private static func imageName(for contentCase: Content) -> String {
+            "\(Asset.settings.rawValue)\(nameInCamelCase(contentCase))"
         }
     }
     
@@ -1160,5 +1178,15 @@ happiggybank@gmail.com으로 문의 부탁드립니다
 
 화면을 탭하면 앱이 종료됩니다
 """
+    }
+}
+
+extension CustomerServiceViewModel {
+    
+    /// 셀 제목
+    enum ContentTitle {
+        
+        /// 라이선스
+        static let license = "라이선스"
     }
 }

--- a/Happiggy-bank/Happiggy-bank/Utils/LicenseText.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/LicenseText.swift
@@ -1,0 +1,70 @@
+//
+//  LicenseText.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/04/21.
+//
+
+import Foundation
+
+extension LicenseViewModel {
+    
+    /// 오픈소스 라이선스 전문
+    static let licenseInformation = """
+# Then
+The MIT License (MIT)
+
+Copyright (c) 2015 Suyeol Jeon (xoul.kr)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+# UPCarouselFlowLayout
+The MIT License (MIT)
+
+Copyright (c) 2016 Paul Ulric
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+# Grid
+Copyright © 2017 Stanford University. All rights reserved.
+
+"Grid.swift" from Happiggy is a derivative of "Grid.swift"(http://web.stanford.edu/class/cs193p/Fall2017/Grid.swift.zip)
+by CS193p(https://cs193p.sites.stanford.edu/about-cs193p) Instructor, Stanford University,
+used under CC BY-NC-SA 4.0(https://creativecommons.org/licenses/by-nc-sa/4.0/),
+and is also licensed under CC BY-NC-SA 4.0 by Happiggy.
+"""
+}

--- a/Happiggy-bank/Happiggy-bank/Utils/LicenseText.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/LicenseText.swift
@@ -7,11 +7,31 @@
 
 import Foundation
 
+// swiftlint:disable line_length
+// MARK: - 오픈소스 라이선스 문자열을 따로 관리하기 위한 익스텐션
 extension LicenseViewModel {
+    
+    /// 오픈소스 라이브러리들
+    static let openSourceLibraries: [String] = [
+        "Then",
+        "UPCarouselFlowLayout",
+        "Grid.swift"
+    ]
+    
+    /// 하이퍼링크를 걸 문자열과 url 딕셔너리
+    static let hyperlinks: [String: String] = [
+        "xoul.kr": "http://xoul.kr",
+        // TODO: Main 으로 주소 변경
+        "Grid.swift from Happiggy": "https://github.com/Happiggy/Happiggy-bank-iOS/blob/develop/Happiggy-bank/Happiggy-bank/Utils/Grid.swift",
+        "\"Grid.swift\"":  "https://cs193p.stanford.edu/Fall2017/Grid.swift.zip",
+        "CS193p": "https://cs193p.sites.stanford.edu/about-cs193p",
+        "CC BY-NC-SA 4.0": "https://creativecommons.org/licenses/by-nc-sa/4.0/"
+    ]
     
     /// 오픈소스 라이선스 전문
     static let licenseInformation = """
-# Then
+Then
+
 The MIT License (MIT)
 
 Copyright (c) 2015 Suyeol Jeon (xoul.kr)
@@ -35,7 +55,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-# UPCarouselFlowLayout
+
+UPCarouselFlowLayout
+
 The MIT License (MIT)
 
 Copyright (c) 2016 Paul Ulric
@@ -59,12 +81,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-# Grid
+
+Grid.swift
+
 Copyright © 2017 Stanford University. All rights reserved.
 
-"Grid.swift" from Happiggy is a derivative of "Grid.swift"(http://web.stanford.edu/class/cs193p/Fall2017/Grid.swift.zip)
-by CS193p(https://cs193p.sites.stanford.edu/about-cs193p) Instructor, Stanford University,
-used under CC BY-NC-SA 4.0(https://creativecommons.org/licenses/by-nc-sa/4.0/),
-and is also licensed under CC BY-NC-SA 4.0 by Happiggy.
+Grid.swift from Happiggy is a derivative of "Grid.swift" by CS193p Instructor(Paul Hegarty), Stanford University, used under CC BY-NC-SA 4.0, and is also licensed under CC BY-NC-SA 4.0 by Happiggy.
 """
 }

--- a/Happiggy-bank/Happiggy-bank/ViewController/CustomerServiceViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/CustomerServiceViewController.swift
@@ -1,0 +1,134 @@
+//
+//  CustomerServiceViewController.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/04/20.
+//
+
+import MessageUI
+import UIKit
+
+/// 고객 지원 뷰 컨트롤러
+final class CustomerServiceViewController: UIViewController {
+    
+    // MARK: - @IBOutlets
+    
+    /// 고객 지원 각 항목을 담고 있는 테이블 뷰
+    @IBOutlet weak var tableView: UITableView!
+    
+    /// 누르면 메일 앱을 띄우는 팀 소개 라벨
+    @IBOutlet weak var teamLabel: UIStackView!
+    
+    
+    // MARK: - Properties
+    
+    private var viewModel = CustomerServiceViewModel()
+    
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.registerCells()
+        self.navigationItem.backButtonTitle = .empty
+    }
+    
+    
+    // MARK: - @IBActions
+    
+    /// 팀 라벨이 탭 되었을 때 호출되는 메서드
+    @IBAction func teamLabelDidTap(_ sender: UITapGestureRecognizer) {
+        self.presentMailApp()
+    }
+    
+    
+    // MARK: - Functions
+    
+    /// 테이블 뷰 셀 등록
+    private func registerCells() {
+        self.tableView.register(
+            UINib(nibName: SettingsNonIconButtonCell.name, bundle: nil),
+            forCellReuseIdentifier: SettingsNonIconButtonCell.name
+        )
+    }
+}
+
+
+// MARK: - MFMailComposeViewControllerDelegate
+/// 메일 관련 메서드, 프로퍼티
+extension CustomerServiceViewController: MFMailComposeViewControllerDelegate {
+    
+    func mailComposeController(
+        _ controller: MFMailComposeViewController,
+        didFinishWith result: MFMailComposeResult,
+        error: Error?
+    ) {
+        controller.dismiss(animated: true)
+    }
+    
+    /// 메일 앱을 모달 뷰로 띄우는 메서드
+    private func presentMailApp() {
+        guard MFMailComposeViewController.canSendMail()
+        else { return }
+        
+        let mailViewController = MFMailComposeViewController().then {
+            $0.mailComposeDelegate = self
+            $0.setToRecipients(SettingsViewController.Mail.recipients)
+            $0.setSubject(SettingsViewController.Mail.subject)
+            $0.setMessageBody(SettingsViewController.Mail.body, isHTML: true)
+        }
+        // TODO: add haptic selection feedback
+        self.present(mailViewController, animated: true)
+    }
+}
+
+
+// MARK: - UITableViewDataSource
+extension CustomerServiceViewController: UITableViewDataSource {
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        self.viewModel.numberOfRowsInSection
+    }
+    
+    func tableView(
+        _ tableView: UITableView,
+        cellForRowAt indexPath: IndexPath
+    ) -> UITableViewCell {
+        
+        self.labelButtonCell(inTableView: tableView, indexPath: indexPath)
+    }
+    
+    /// 라벨 버튼 셀 모습 설정
+    private func labelButtonCell(
+        inTableView tableView: UITableView,
+        indexPath: IndexPath
+    ) -> UITableViewCell {
+        
+        guard let cell = tableView.dequeueReusableCell(
+            withIdentifier: SettingsNonIconButtonCell.name,
+            for: indexPath
+        ) as? SettingsNonIconButtonCell
+        else { return SettingsNonIconButtonCell() }
+        
+        cell.titleLabel.text = self.viewModel.title(forContentAt: indexPath)
+        
+        return cell
+    }
+}
+
+
+// MARK: - UITableViewDelegate
+extension CustomerServiceViewController: UITableViewDelegate {
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        
+        tableView.deselectRow(at: indexPath, animated: false)
+        
+        guard let segueIdentifier = self.viewModel.segueIdentifier(forContentAt: indexPath)
+        else { return }
+        
+        self.performSegue(withIdentifier: segueIdentifier, sender: self)
+        HapticManager.instance.selection()
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/ViewController/CustomerServiceViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/CustomerServiceViewController.swift
@@ -125,10 +125,10 @@ extension CustomerServiceViewController: UITableViewDelegate {
         
         tableView.deselectRow(at: indexPath, animated: false)
         
-        guard let segueIdentifier = self.viewModel.segueIdentifier(forContentAt: indexPath)
+        guard let destination = self.viewModel.destination(forContentAt: indexPath)
         else { return }
         
-        self.performSegue(withIdentifier: segueIdentifier, sender: self)
+        self.show(destination, sender: self)
         HapticManager.instance.selection()
     }
 }

--- a/Happiggy-bank/Happiggy-bank/ViewController/InformationTextViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/InformationTextViewController.swift
@@ -1,0 +1,64 @@
+//
+//  InformationTextViewController.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/04/21.
+//
+
+import UIKit
+
+/// 정보를 담은 단일 텍스트 뷰를 나타내는 컨트롤러
+final class InformationTextViewController: UIViewController {
+    
+    // MARK: - @IBOutlets
+    
+    /// 정보를 담을 텍스트뷰 
+    @IBOutlet weak var textView: UITextView!
+    
+    
+    // MARK: - Properties
+    
+    /// 뷰모델
+    private var viewModel: InformationTextViewDataSource!
+    
+    
+    // MARK: - Inits
+    
+    init?(coder: NSCoder, viewModel: InformationTextViewDataSource) {
+        super.init(coder: coder)
+        
+        self.viewModel = viewModel
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        
+        print("don't use me!")
+    }
+    
+    
+    // MARK: - Life Cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.textView.attributedText = self.viewModel.attributedInformationString
+        self.configureNavigationBar()
+    }
+    
+    
+    // MARK: - Functions
+    
+    /// 내비게이션 바 초기 설정
+    private func configureNavigationBar() {
+        self.navigationItem.title = self.viewModel.navigationTitle
+        self.removeNavigationBarSeperator()
+    }
+    
+    /// 내비게이션 바 하단 구분 선 제거
+    private func removeNavigationBarSeperator() {
+        let navigationBar = self.navigationController?.navigationBar
+        
+        navigationBar?.setBackgroundImage(UIImage(), for: .default)
+        navigationBar?.shadowImage = UIImage()
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/ViewController/InformationTextViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/InformationTextViewController.swift
@@ -41,8 +41,8 @@ final class InformationTextViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.textView.attributedText = self.viewModel.attributedInformationString
         self.configureNavigationBar()
+        self.configureTextView()
     }
     
     
@@ -60,5 +60,10 @@ final class InformationTextViewController: UIViewController {
         
         navigationBar?.setBackgroundImage(UIImage(), for: .default)
         navigationBar?.shadowImage = UIImage()
+    }
+    
+    /// 텍스트뷰 초기 설정
+    private func configureTextView() {
+        self.textView.attributedText = self.viewModel.attributedInformationString
     }
 }

--- a/Happiggy-bank/Happiggy-bank/ViewController/InformationTextViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/InformationTextViewController.swift
@@ -65,5 +65,6 @@ final class InformationTextViewController: UIViewController {
     /// 텍스트뷰 초기 설정
     private func configureTextView() {
         self.textView.attributedText = self.viewModel.attributedInformationString
+        self.textView.textColor = .label
     }
 }

--- a/Happiggy-bank/Happiggy-bank/ViewController/SettingsViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/SettingsViewController.swift
@@ -10,13 +10,13 @@ import UIKit
 
 /// 환경 설정 뷰 컨트롤러
 final class SettingsViewController: UIViewController {
-
+    
     // MARK: - @IBOutlets
     
     /// 환경 설정 각 항목을 담고 있는 테이블 뷰
     @IBOutlet weak var tableView: UITableView!
     
-    /// 누르면 깃헙 레포로 넘어가는 팀 소개 라벨
+    /// 누르면 메일 앱을 띄우는 팀 소개 라벨
     @IBOutlet weak var teamLabel: UIStackView!
     
     
@@ -31,6 +31,7 @@ final class SettingsViewController: UIViewController {
         super.viewDidLoad()
         
         self.registerCells()
+        self.navigationItem.backButtonTitle = .empty
     }
     
     
@@ -60,10 +61,11 @@ final class SettingsViewController: UIViewController {
 
 // MARK: - UITableViewDataSource
 extension SettingsViewController: UITableViewDataSource {
+    
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         Content.allCases.count
     }
-
+    
     func tableView(
         _ tableView: UITableView,
         cellForRowAt indexPath: IndexPath
@@ -80,10 +82,9 @@ extension SettingsViewController: UITableViewDataSource {
             return cell
         }
         
-//        if indexPath.row == Content.appVersion.rawValue ||
-//            indexPath.row == Content.license.rawValue {
-        if indexPath.row == Content.appVersion.rawValue {
-
+        if indexPath.row == Content.appVersion.rawValue ||
+            indexPath.row == Content.customerService.rawValue {
+            
             return self.labelButtonCell(
                 inTableView: tableView,
                 indexPath: indexPath,
@@ -172,15 +173,16 @@ extension SettingsViewController: MFMailComposeViewControllerDelegate {
 
 
 // MARK: - UITableViewDelegate
-// extension SettingsViewController: UITableViewDelegate {
-//
-//    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-//
-//        tableView.deselectRow(at: indexPath, animated: false)
-//
-//        if indexPath.row == Content.license.rawValue {
-//            // TODO: 라이선스 뷰컨트롤러로 이동
-//            HapticManager.instance.selection()
-//        }
-//    }
-// }
+extension SettingsViewController: UITableViewDelegate {
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        
+        tableView.deselectRow(at: indexPath, animated: false)
+        
+        guard let segueIdentifier = self.viewModel.segueIdentifier(forContentAt: indexPath)
+        else { return }
+        
+        self.performSegue(withIdentifier: segueIdentifier, sender: self)
+        HapticManager.instance.selection()
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/ViewModel/CustomerServiceViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/CustomerServiceViewModel.swift
@@ -49,9 +49,10 @@ final class CustomerServiceViewModel {
             return storyboard.instantiateViewController(
                 identifier: InformationTextViewController.name
             ) { coder in
-                InformationTextViewController(coder: coder, viewModel: LicenseViewModel())
+                let viewModel = LicenseViewModel(navigationTitle: ContentTitle.license)
+                
+                return InformationTextViewController(coder: coder, viewModel: viewModel)
             }
-            
         }
         
         return nil

--- a/Happiggy-bank/Happiggy-bank/ViewModel/CustomerServiceViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/CustomerServiceViewModel.swift
@@ -1,0 +1,69 @@
+//
+//  CustomerServiceViewModel.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/04/20.
+//
+
+import UIKit
+
+/// 고객 지원 뷰 컨트롤러의 뷰모델
+final class CustomerServiceViewModel {
+    
+    // MARK: - Enums
+    
+    // 셀별 내용
+    private enum Content: Int, CaseIterable {
+        
+        /// 라이선스
+        case license
+        
+        
+        // MARK: - Properties
+        
+        /// 제목 딕셔너리
+        static let title: [Int: String] = [
+            license.rawValue: ContentTitle.license
+        ]
+        
+        /// 세그웨이 아이디 딕셔너리
+        static let segueIdentifier: [Int: String] = [
+            license.rawValue: segueIdentifier(for: license)
+        ]
+        
+        
+        // MARK: - Functions
+        
+        /// 케이스 이름을 카멜케이스로 변환
+        private static func nameInCamelCase(_ contentCase: Content) -> String {
+            var contentCase = "\(contentCase.self)"
+            let firstLetter = contentCase.removeFirst().uppercased()
+            
+            return firstLetter.appending(contentCase)
+        }
+        
+        /// 세그웨이 아이디 리턴
+        private static func segueIdentifier(for contentCase: Content) -> String {
+            "show\(nameInCamelCase(contentCase))View"
+        }
+    }
+    
+    
+    // MARK: - Properties
+    
+    /// 섹션의 행 개수
+    private(set) var numberOfRowsInSection = Content.allCases.count
+    
+    
+    // MARK: - Functions
+    
+    /// 해당 칸의 제목 리턴
+    func title(forContentAt indexPath: IndexPath) -> String? {
+        Content.title[indexPath.row]
+    }
+    
+    /// 세그웨이가 있다면 해당 세그웨이의 아이디 리턴
+    func segueIdentifier(forContentAt indexPath: IndexPath) -> String? {
+        Content.segueIdentifier[indexPath.row]
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/ViewModel/CustomerServiceViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/CustomerServiceViewModel.swift
@@ -25,27 +25,6 @@ final class CustomerServiceViewModel {
         static let title: [Int: String] = [
             license.rawValue: ContentTitle.license
         ]
-        
-        /// 세그웨이 아이디 딕셔너리
-        static let segueIdentifier: [Int: String] = [
-            license.rawValue: segueIdentifier(for: license)
-        ]
-        
-        
-        // MARK: - Functions
-        
-        /// 케이스 이름을 카멜케이스로 변환
-        private static func nameInCamelCase(_ contentCase: Content) -> String {
-            var contentCase = "\(contentCase.self)"
-            let firstLetter = contentCase.removeFirst().uppercased()
-            
-            return firstLetter.appending(contentCase)
-        }
-        
-        /// 세그웨이 아이디 리턴
-        private static func segueIdentifier(for contentCase: Content) -> String {
-            "show\(nameInCamelCase(contentCase))View"
-        }
     }
     
     
@@ -62,8 +41,19 @@ final class CustomerServiceViewModel {
         Content.title[indexPath.row]
     }
     
-    /// 세그웨이가 있다면 해당 세그웨이의 아이디 리턴
-    func segueIdentifier(forContentAt indexPath: IndexPath) -> String? {
-        Content.segueIdentifier[indexPath.row]
+    /// 내비게이션이 필요한 경우 내비게이션으로 넘어갈 뷰컨트롤러 리턴
+    func destination(forContentAt indexPath: IndexPath) -> UIViewController? {
+        let storyboard = UIStoryboard(name: mainStoryboardName, bundle: .main)
+
+        if indexPath.row ==  Content.license.rawValue {
+            return storyboard.instantiateViewController(
+                identifier: InformationTextViewController.name
+            ) { coder in
+                InformationTextViewController(coder: coder, viewModel: LicenseViewModel())
+            }
+            
+        }
+        
+        return nil
     }
 }

--- a/Happiggy-bank/Happiggy-bank/ViewModel/LicenseViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/LicenseViewModel.swift
@@ -1,0 +1,19 @@
+//
+//  LicenseViewModel.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/04/21.
+//
+
+import Foundation
+
+/// 환경설정-고객지원-라이선스 항목의 뷰 모델
+final class LicenseViewModel: InformationTextViewDataSource {
+    
+    private(set) var navigationTitle: String? = "라이선스"
+    
+    private(set) var attributedInformationString: NSAttributedString? = {
+        licenseInformation
+            .nsMutableAttributedStringify()
+    }()
+}

--- a/Happiggy-bank/Happiggy-bank/ViewModel/LicenseViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/LicenseViewModel.swift
@@ -10,10 +10,26 @@ import Foundation
 /// 환경설정-고객지원-라이선스 항목의 뷰 모델
 final class LicenseViewModel: InformationTextViewDataSource {
     
-    private(set) var navigationTitle: String? = "라이선스"
+    // MARK: - Properties
+    
+    private(set) var navigationTitle: String?
     
     private(set) var attributedInformationString: NSAttributedString? = {
-        licenseInformation
+        let attributedString = licenseInformation
             .nsMutableAttributedStringify()
+            .addHyperLinks(hyperlinks: hyperlinks)
+        
+        openSourceLibraries.forEach {
+            attributedString.bold(targetString: $0, fontSize: Font.boldFontSize)
+        }
+        
+        return attributedString
     }()
+    
+    
+    // MARK: - Inits
+    
+    init(navigationTitle: String?) {
+        self.navigationTitle = navigationTitle
+    }
 }

--- a/Happiggy-bank/Happiggy-bank/ViewModel/SettingsViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/SettingsViewModel.swift
@@ -10,26 +10,23 @@ import UIKit
 /// 환경설정 뷰 컨트롤러의 뷰모델
 final class SettingsViewModel {
     
+    typealias Content = SettingsViewController.Content
+
+    
     // MARK: - Functions
     
     /// 해당 칸의 아이콘 이미지 리턴
     func icon(forContentAt indexPath: IndexPath) -> UIImage? {
-        typealias Content = SettingsViewController.Content
-        
-        return Content.icon[indexPath.row] ?? nil
+        Content.icon[indexPath.row] ?? nil
     }
     
     /// 해당 칸의 제목 리턴
     func title(forContentAt indexPath: IndexPath) -> NSMutableAttributedString? {
-        typealias Content = SettingsViewController.Content
-        
-         return Content.title[indexPath.row]?.nsMutableAttributedStringify()
+        Content.title[indexPath.row]?.nsMutableAttributedStringify()
     }
     
     /// 해당 칸의 설명 리턴
     func informationText(forContentAt indexPath: IndexPath) -> NSMutableAttributedString? {
-        typealias Content = SettingsViewController.Content
-        
         let text = Content.informationText[indexPath.row]?.nsMutableAttributedStringify()
         
         if indexPath.row == Content.appVersion.rawValue {
@@ -37,5 +34,10 @@ final class SettingsViewModel {
         }
         
         return text
+    }
+    
+    /// 세그웨이가 있다면 해당 세그웨이의 아이디 리턴
+    func segueIdentifier(forContentAt indexPath: IndexPath) -> String? {
+        Content.segueIdentifier[indexPath.row]
     }
 }


### PR DESCRIPTION
## 반영 내용
- 이슈 #144
- 이슈 #173 

<br>

### 고객 지원 뷰 
- 버전 2에서 이용약관, 개인보호 처리방침 탭이 생길 예정이므로 환경설정에 고객 지원 탭을 별도로 생성하고 라이선스뷰를 해당 항목의 하위 항목으로 추가했습니다. 
- 최대한 셀 구성 관련 로직을 뷰모델로 빼서 뷰 컨트롤러는 받아서 최종적으로 이를 UI 와 연결하는 역할만 수행하도록 했습니다. 

<br>

### 라이선스 뷰
- 나중에 이용약관, 개인보호 처리방침 뷰도 같은 형태일거라고 생각해서 재사용성을 높이기 위해 InformationTextViewController 를 생성했습니다. 
- 마찬가지로 결합도를 낮추고 재사용성을 높이기 위해 위해 InformationTextViewDataSource 프로토콜을 선언해서 뷰모델의 타입을 추상화했습니다.
  - 각 케이스마다 내비게이션바 제목이랑 텍스트뷰 텍스트만 바뀔거 같아서 이렇게 하면 나중에 재사용하기 쉽겠다..!했는데 나중 가면 또 구려서 엎을수도... 
- 라이선스 내용 중 필요한 곳에 하이퍼링크를 추가했습니다. 
  - 하이퍼링크 생성 관련 코드는 익스텐션으로 추가했습니당!

<br>

## 추후 작업
- (만약 디자이너님이 추가하겠다고 하시면) 아이콘 에셋 반영