### PR TITLE
[fix] 새로운 쪽지 날짜 피커 경고 라벨 사라지지 않는 현상 해결 #178

### DIFF
--- a/Happiggy-bank/Happiggy-bank/ViewController/NewNoteDatePickerViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NewNoteDatePickerViewController.swift
@@ -269,11 +269,6 @@ extension NewNoteDatePickerViewController: UIPickerViewDelegate {
         reusing view: UIView?
     ) -> UIView {
         
-        if self.showWarningLabel {
-            self.warningLabel.fadeOut()
-            self.showWarningLabel = false
-        }
-        
         let row = self.validatedRow(row)
         let noteData = self.viewModel.noteData[row]
         let rowView = view as? NewNoteDatePickerRowView ?? NewNoteDatePickerRowView()
@@ -308,6 +303,12 @@ extension NewNoteDatePickerViewController: UIPickerViewDelegate {
         }
         
         self.viewModel.selectedDate = noteData.date
+
+        guard self.showWarningLabel
+        else { return }
+        
+        self.warningLabel.fadeOut()
+        self.showWarningLabel = false
     }
     
     /// 0보다 작은 인덱스가 들어오면 0, 최대 개수보다 큰 값이 들어오면 마지막 인덱스로 바꿔주는 메서드


### PR DESCRIPTION
## 작업내용
- 이슈 #178 

<br>

- 경고 라벨 페이드 아웃 로직이 현재 화면에 나타나는 행에 사용될 뷰를 리턴하는 델리게이트 메서드에 들어있어서, 스크롤을 적게 하는 경우 이미 필요한 뷰가 모두 그려져 있어 해당 메서드가 호출되지 않기 때문에 발생하는 문제였습니다. 
- 따라서 페이드아웃 로직을 행 선택시 호출되는 델리게이트 메서드로 옮겨줬습니다. 