### PR TITLE
[feat] 개발자에게 메일 보내기 기능 고객지원 뷰로 이동 #175

### DIFF
--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -422,7 +422,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="813"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="79" estimatedRowHeight="79" sectionHeaderHeight="28" estimatedSectionHeaderHeight="-1" sectionFooterHeight="28" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="XH5-F4-UT7">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="66" estimatedRowHeight="66" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="XH5-F4-UT7">
                                 <rect key="frame" x="0.0" y="88" width="414" height="594"/>
                                 <inset key="separatorInset" minX="24" minY="0.0" maxX="24" maxY="0.0"/>
                                 <connections>
@@ -491,7 +491,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="813"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="79" estimatedRowHeight="79" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="uQp-S9-PAW">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="66" estimatedRowHeight="66" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="uQp-S9-PAW">
                                 <rect key="frame" x="0.0" y="88" width="414" height="594"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <connections>

--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -842,7 +842,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="하루 한 번, 100자로 행복을 기록하세요:)" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4S5-fe-Oby">
-                                <rect key="frame" x="24" y="208" width="286.5" height="21.5"/>
+                                <rect key="frame" x="24" y="208" width="327" height="21.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                 <color key="textColor" name="placeholderTextColor"/>
                                 <nil key="highlightedColor"/>
@@ -855,6 +855,7 @@
                             <constraint firstItem="4S5-fe-Oby" firstAttribute="top" secondItem="fvK-sf-BF4" secondAttribute="top" id="C94-VV-ivR"/>
                             <constraint firstItem="HX4-ny-KZ7" firstAttribute="bottom" secondItem="GeA-rS-UHc" secondAttribute="bottom" constant="-24" id="Cw3-em-GXv"/>
                             <constraint firstItem="fvK-sf-BF4" firstAttribute="leading" secondItem="Qg8-yI-fTV" secondAttribute="leading" constant="-5" id="FRT-hw-tFd"/>
+                            <constraint firstItem="4S5-fe-Oby" firstAttribute="trailing" secondItem="fvK-sf-BF4" secondAttribute="trailing" id="Fy6-eB-YdM"/>
                             <constraint firstItem="Rms-YT-wWN" firstAttribute="top" secondItem="1PQ-Bn-66w" secondAttribute="top" constant="44" id="Gyw-ql-9vl"/>
                             <constraint firstAttribute="trailing" secondItem="m3m-FL-apG" secondAttribute="trailing" id="Kxl-BE-f54"/>
                             <constraint firstItem="Rms-YT-wWN" firstAttribute="leading" secondItem="1PQ-Bn-66w" secondAttribute="leading" id="LBS-sy-BL8"/>

--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -423,7 +423,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="79" estimatedRowHeight="79" sectionHeaderHeight="28" estimatedSectionHeaderHeight="-1" sectionFooterHeight="28" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="XH5-F4-UT7">
-                                <rect key="frame" x="0.0" y="88" width="414" height="628"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="594"/>
                                 <inset key="separatorInset" minX="24" minY="0.0" maxX="24" maxY="0.0"/>
                                 <connections>
                                     <outlet property="dataSource" destination="IlI-sf-Vas" id="nPy-Qt-GrC"/>
@@ -431,25 +431,25 @@
                                 </connections>
                             </tableView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="b4d-oF-HEA">
-                                <rect key="frame" x="127" y="732" width="160" height="57"/>
+                                <rect key="frame" x="141.5" y="698" width="131.5" height="91"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Happiggy" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3QJ-R7-7AU">
-                                        <rect key="frame" x="0.0" y="0.0" width="160" height="17"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="131.5" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" name="customGray"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="QIP-2t-A8R">
-                                        <rect key="frame" x="0.0" y="24" width="160" height="33"/>
+                                        <rect key="frame" x="0.0" y="24" width="131.5" height="67"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2unbini mseo sun h1" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pBU-xg-BjY">
-                                                <rect key="frame" x="0.0" y="0.0" width="160" height="17"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="131.5" height="17"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <color key="textColor" name="customGray"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="happiggybank@gmail.com" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rpq-ey-KQm">
-                                                <rect key="frame" x="0.0" y="17" width="160" height="16"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rpq-ey-KQm">
+                                                <rect key="frame" x="0.0" y="17" width="131.5" height="50"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                 <color key="textColor" name="customGray"/>
                                                 <nil key="highlightedColor"/>
@@ -458,9 +458,6 @@
                                     </stackView>
                                 </subviews>
                                 <gestureRecognizers/>
-                                <connections>
-                                    <outletCollection property="gestureRecognizers" destination="lsy-he-ebl" appends="YES" id="6EQ-Qb-XdG"/>
-                                </connections>
                             </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="NL0-gI-uP8"/>
@@ -483,11 +480,6 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="aNi-4h-ywR" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-                <tapGestureRecognizer id="lsy-he-ebl">
-                    <connections>
-                        <action selector="teamLabelDidTap:" destination="IlI-sf-Vas" id="J5n-bv-v6a"/>
-                    </connections>
-                </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="2965.5999999999999" y="1642.6108374384237"/>
         </scene>
@@ -500,42 +492,39 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="79" estimatedRowHeight="79" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="uQp-S9-PAW">
-                                <rect key="frame" x="0.0" y="88" width="414" height="628"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="594"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <connections>
                                     <outlet property="dataSource" destination="Tl4-Fc-9VF" id="c5C-I0-D53"/>
                                     <outlet property="delegate" destination="Tl4-Fc-9VF" id="E3V-Gc-lfh"/>
                                 </connections>
                             </tableView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="zPR-tj-0Fk">
-                                <rect key="frame" x="127" y="732" width="160" height="57"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="zPR-tj-0Fk" userLabel="Team Label">
+                                <rect key="frame" x="141.5" y="698" width="131.5" height="91"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Happiggy" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xVA-yW-8B5">
-                                        <rect key="frame" x="0.0" y="0.0" width="160" height="17"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="131.5" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" name="customGray"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="xZO-XM-fFz">
-                                        <rect key="frame" x="0.0" y="24" width="160" height="33"/>
+                                        <rect key="frame" x="0.0" y="24" width="131.5" height="67"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2unbini mseo sun h1" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J3d-Ov-mmP">
-                                                <rect key="frame" x="0.0" y="0.0" width="160" height="17"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="131.5" height="17"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <color key="textColor" name="customGray"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="happiggybank@gmail.com" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NZA-in-aRZ">
-                                                <rect key="frame" x="0.0" y="17" width="160" height="16"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NZA-in-aRZ">
+                                                <rect key="frame" x="0.0" y="17" width="131.5" height="50"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                 <color key="textColor" name="customGray"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
                                         <gestureRecognizers/>
-                                        <connections>
-                                            <outletCollection property="gestureRecognizers" destination="bk9-d1-qQ2" appends="YES" id="CMV-YJ-mKO"/>
-                                        </connections>
                                     </stackView>
                                 </subviews>
                                 <gestureRecognizers/>
@@ -555,16 +544,11 @@
                     <navigationItem key="navigationItem" title="고객 지원" id="Pv5-p6-rLV"/>
                     <connections>
                         <outlet property="tableView" destination="uQp-S9-PAW" id="wxA-zr-YMs"/>
-                        <outlet property="teamLabel" destination="xZO-XM-fFz" id="OWN-SM-M6q"/>
+                        <outlet property="teamLabel" destination="zPR-tj-0Fk" id="jb5-RB-RGq"/>
                         <segue destination="nkh-H8-Hta" kind="show" identifier="showLicenseView" id="53q-OE-6qo"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="rhR-vq-qOh" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-                <tapGestureRecognizer id="bk9-d1-qQ2">
-                    <connections>
-                        <action selector="teamLabelDidTap:" destination="Tl4-Fc-9VF" id="Ptm-Kx-BiZ"/>
-                    </connections>
-                </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="4316" y="2446"/>
         </scene>

--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -566,7 +566,7 @@
                     </connections>
                 </tapGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="4316" y="2462"/>
+            <point key="canvasLocation" x="4316" y="2446"/>
         </scene>
         <!--Information Text View Controller-->
         <scene sceneID="av6-PB-qbi">

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -1188,6 +1188,32 @@ extension CustomerServiceViewModel {
         
         /// 라이선스
         static let license = "라이선스"
+        
+        /// 메일
+        static let mail = "의견 보내기"
+    }
+    
+    /// 메일 앱 관련 문자열
+    enum Mail {
+        
+        /// 팀 이메일
+        static let teamMail = "happiggybank@gmail.com"
+        
+        /// 제목: [행복저금통]
+        static let subject = "[행복저금통]"
+        
+        /// 내용
+        static let body =
+        "<p style=\"color:gray\">버그 발생 시 디바이스 이름, iOS 버전을 함께 알려주시면 감사하겠습니다:)</p>"
+        
+        /// 메일을 보낼 수 없을 때 띄울 알림의 제목
+        static let alertTitle = "메일 앱을 열 수 없습니다"
+        
+        /// 메일을 보낼 수 없을 때 띄울 알림의 내용
+        static let alertMessage = """
+\(teamMail)
+으로 의견을 보내주세요!
+"""
     }
 }
 

--- a/Happiggy-bank/Happiggy-bank/ViewController/CustomerServiceViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/CustomerServiceViewController.swift
@@ -79,7 +79,7 @@ extension CustomerServiceViewController: MFMailComposeViewControllerDelegate {
             $0.setMessageBody(SettingsViewController.Mail.body, isHTML: true)
         }
         // TODO: add haptic selection feedback
-        self.present(mailViewController, animated: true)
+        self.show(mailViewController, sender: self)
     }
 }
 
@@ -125,10 +125,17 @@ extension CustomerServiceViewController: UITableViewDelegate {
         
         tableView.deselectRow(at: indexPath, animated: false)
         
-        guard let destination = self.viewModel.destination(forContentAt: indexPath)
+        guard let destination = self.viewModel.destination(forContentAt: indexPath, delegate: self)
         else { return }
         
-        self.show(destination, sender: self)
         HapticManager.instance.selection()
+
+        guard let alert = destination as? UIAlertController
+        else {
+            self.show(destination, sender: self)
+            return
+        }
+        
+        self.present(alert, animated: true)
     }
 }

--- a/Happiggy-bank/Happiggy-bank/ViewController/CustomerServiceViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/CustomerServiceViewController.swift
@@ -35,14 +35,6 @@ final class CustomerServiceViewController: UIViewController {
     }
     
     
-    // MARK: - @IBActions
-    
-    /// 팀 라벨이 탭 되었을 때 호출되는 메서드
-    @IBAction func teamLabelDidTap(_ sender: UITapGestureRecognizer) {
-        self.presentMailApp()
-    }
-    
-    
     // MARK: - Functions
     
     /// 테이블 뷰 셀 등록
@@ -65,21 +57,6 @@ extension CustomerServiceViewController: MFMailComposeViewControllerDelegate {
         error: Error?
     ) {
         controller.dismiss(animated: true)
-    }
-    
-    /// 메일 앱을 모달 뷰로 띄우는 메서드
-    private func presentMailApp() {
-        guard MFMailComposeViewController.canSendMail()
-        else { return }
-        
-        let mailViewController = MFMailComposeViewController().then {
-            $0.mailComposeDelegate = self
-            $0.setToRecipients(SettingsViewController.Mail.recipients)
-            $0.setSubject(SettingsViewController.Mail.subject)
-            $0.setMessageBody(SettingsViewController.Mail.body, isHTML: true)
-        }
-        // TODO: add haptic selection feedback
-        self.show(mailViewController, sender: self)
     }
 }
 

--- a/Happiggy-bank/Happiggy-bank/ViewController/SettingsViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/SettingsViewController.swift
@@ -35,14 +35,6 @@ final class SettingsViewController: UIViewController {
     }
     
     
-    // MARK: - @IBActions
-    
-    /// 팀 라벨이 탭 되었을 때 호출되는 메서드
-    @IBAction func teamLabelDidTap(_ sender: UITapGestureRecognizer) {
-        self.presentMailApp()
-    }
-    
-    
     // MARK: - Functions
     
     /// 테이블 뷰 셀 등록
@@ -153,21 +145,6 @@ extension SettingsViewController: MFMailComposeViewControllerDelegate {
         error: Error?
     ) {
         controller.dismiss(animated: true)
-    }
-    
-    /// 메일 앱을 모달 뷰로 띄우는 메서드
-    private func presentMailApp() {
-        guard MFMailComposeViewController.canSendMail()
-        else { return }
-        
-        let mailViewController = MFMailComposeViewController().then {
-            $0.mailComposeDelegate = self
-            $0.setToRecipients(Mail.recipients)
-            $0.setSubject(Mail.subject)
-            $0.setMessageBody(Mail.body, isHTML: true)
-        }
-        // TODO: add haptic selection feedback
-        present(mailViewController, animated: true)
     }
 }
 

--- a/Happiggy-bank/Happiggy-bank/ViewModel/CustomerServiceViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/CustomerServiceViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by sun on 2022/04/20.
 //
 
+import MessageUI
 import UIKit
 
 /// 고객 지원 뷰 컨트롤러의 뷰모델
@@ -18,12 +19,16 @@ final class CustomerServiceViewModel {
         /// 라이선스
         case license
         
+        /// 메일
+        case mail
+        
         
         // MARK: - Properties
         
         /// 제목 딕셔너리
         static let title: [Int: String] = [
-            license.rawValue: ContentTitle.license
+            license.rawValue: ContentTitle.license,
+            mail.rawValue: ContentTitle.mail
         ]
     }
     
@@ -42,10 +47,13 @@ final class CustomerServiceViewModel {
     }
     
     /// 내비게이션이 필요한 경우 내비게이션으로 넘어갈 뷰컨트롤러 리턴
-    func destination(forContentAt indexPath: IndexPath) -> UIViewController? {
+    func destination(
+        forContentAt indexPath: IndexPath,
+        delegate: UIViewController
+    ) -> UIViewController? {
         let storyboard = UIStoryboard(name: mainStoryboardName, bundle: .main)
-
-        if indexPath.row ==  Content.license.rawValue {
+        
+        if indexPath.row == Content.license.rawValue {
             return storyboard.instantiateViewController(
                 identifier: InformationTextViewController.name
             ) { coder in
@@ -55,6 +63,30 @@ final class CustomerServiceViewModel {
             }
         }
         
+        if indexPath.row == Content.mail.rawValue {
+            guard MFMailComposeViewController.canSendMail(),
+                  let delegate = delegate as? MFMailComposeViewControllerDelegate
+            else { return self.cannotSendMailAlert() }
+            
+            let mailViewController = MFMailComposeViewController().then {
+                $0.mailComposeDelegate = delegate
+                $0.setToRecipients([Mail.teamMail])
+                $0.setSubject(Mail.subject)
+                $0.setMessageBody(Mail.body, isHTML: true)
+            }
+            
+            return mailViewController
+        }
+        
         return nil
+    }
+    
+    /// 메일을 보낼 수 없을 때 나타낼 알림을 생성
+    private func cannotSendMailAlert() -> UIAlertController {
+        UIAlertController.basic(
+            alertTitle: Mail.alertTitle,
+            alertMessage: Mail.alertMessage,
+            confirmAction: UIAlertAction.confirmAction()
+        )
     }
 }


### PR DESCRIPTION
## 작업내용
- 이슈 #175 

<br>

### 개발자에게 메일 보내기 기능 고객 지원 뷰로 이동
- 기존에 팀 소개 라벨에 있던 기능을 고객 지원 뷰로 이동했습니다. 
- 메일 앱을 열 수 있는 경우 모달로 메일 작성 메뉴를 띄우고, 불가능한 경우 메일 주소가 써 있는 알림을 띄우도록 했습니다. 
- 팀 라벨에서 메일 주소를 삭제했습니다. 추후에 여기 앱 소개 노션 링크같은 걸 달아도 좋을 것 같아서 일단 탭제스처 레코나이저는 살려뒀습니다...!